### PR TITLE
feat: add fastly provider

### DIFF
--- a/docs/content/en/providers.md
+++ b/docs/content/en/providers.md
@@ -43,8 +43,6 @@ export default {
 }
 ```
 
-
-
 ## `twicpics`
 
 Integration between [Twicpics](https://www.twicpics.com) and the image module.  
@@ -56,6 +54,24 @@ export default {
     providers: {
       twicpics: {
         baseURL: 'https://i5acur1u.twic.pics'
+      }
+    }
+  }
+}
+```
+
+## `fastly`
+
+Integration between [Fastly](https://docs.fastly.com/en/guides/image-optimization-api)
+and the image module. To use this provider you just need to specify the base url
+of your service in Fastly.
+
+```js{}[nuxt.config.js]
+export default {
+  image: {
+    providers: {
+      fastly: {
+        baseURL: 'https://www.fastly.io'
       }
     }
   }

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -23,6 +23,9 @@ export default {
       },
       cloudinary: {
         baseURL: 'https://res.cloudinary.com/farnabaz/image/upload'
+      },
+      fastly: {
+        baseURL: 'https://www.fastly.io'
       }
     }
   }

--- a/src/providers/fastly/index.ts
+++ b/src/providers/fastly/index.ts
@@ -1,0 +1,8 @@
+import { ProviderFactory } from 'types'
+
+export default <ProviderFactory> function (providerOptions) {
+  return {
+    runtime: require.resolve('./runtime'),
+    runtimeOptions: providerOptions
+  }
+}

--- a/src/providers/fastly/runtime.ts
+++ b/src/providers/fastly/runtime.ts
@@ -1,0 +1,44 @@
+import { RuntimeProvider, ImageModifiers } from 'types'
+
+function getSizeOperator (size) {
+  if (!size) {
+    return 'bounds'
+  }
+  switch (size) {
+    case 'contain':
+      return 'bounds'
+    case 'fill':
+    case 'inside':
+    case 'outside':
+      return 'crop'
+    default:
+      return size
+  }
+}
+
+export default <RuntimeProvider> {
+  generateURL (src: string, modifiers: ImageModifiers, options: any) {
+    const { width, height, format, size, ...providerModifiers } = modifiers
+    const operations = []
+
+    if (width) {
+      operations.push('width=' + encodeURIComponent(width))
+    }
+    if (height) {
+      operations.push('height=' + encodeURIComponent(height))
+    }
+    if (format) {
+      operations.push('format=' + encodeURIComponent(format))
+    }
+    operations.push('fit=' + encodeURIComponent(getSizeOperator(size)))
+
+    Object.entries(providerModifiers).forEach(([key, value]) => {
+      operations.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    })
+
+    const operationsString = operations.join('&')
+    return {
+      url: (options.baseURL + src + '?' + operationsString).replace(/(https?:\/\/)|(\/)+/g, '$1$2')
+    }
+  }
+}


### PR DESCRIPTION
This adds a [fastly image optimization](https://docs.fastly.com/en/guides/image-optimization-api) provider.

- I tried to get the size operator matched up as much as I could, but they only have three options. 
- I added a fastly url, but because it's a demo url, the only available image to test on is [`/image.jpg`](https://www.fastly.io/image.jpg)