### PR TITLE
docs: give <img> empty alt="" attribute

### DIFF
--- a/docs/content/en/index.md
+++ b/docs/content/en/index.md
@@ -9,8 +9,8 @@ features:
   - CDN Support
 ---
 
-<nuxt-image src="/preview.png" width="664" height="332" class="light-img"></nuxt-image>
-<nuxt-image src="/preview-dark.png" width="664" height="332" class="dark-img"></nuxt-image>
+<nuxt-image src="/preview.png" width="664" height="332" class="light-img" alt=""></nuxt-image>
+<nuxt-image src="/preview-dark.png" width="664" height="332" class="dark-img" alt=""></nuxt-image>
 
 Optimised images for [NuxtJS](https://nuxtjs.org).
 


### PR DESCRIPTION
Improved accessibility. Added empty alt="" attributes to remove the decorative images from the accessibility tree.
