### PR TITLE
docs: fix typos in content

### DIFF
--- a/docs/content/en/custom-provider.md
+++ b/docs/content/en/custom-provider.md
@@ -68,7 +68,7 @@ export default {
 
 Although there is planty of great image provider services out there but sometimes having your own is more fun and may be more customizable. If you want to use image manipulation libraries like [node-canvas](https://github.com/Automattic/node-canvas), [jimp](https://github.com/oliver-moran/jimp), [GraphicsMagick](https://github.com/aheckmann/gm) or any other great library you need to create a middleware for your provider.  
 A middleware is just a [server-middleware for nuxt](https://nuxtjs.org/api/configuration-servermiddleware#custom-server-middleware) that receives generated url and return optimized image.  
-Below exmple shows simple middleware that returns single image.
+Below example shows simple middleware that returns single image.
 
 ```js
 function createMiddleware(options) {

--- a/docs/content/en/nuxt-image.md
+++ b/docs/content/en/nuxt-image.md
@@ -107,7 +107,7 @@ Presets are predefined sets of image modifiers that can be used create unified f
 
 ### Provider + Presets
 
-As you may notice providers and presets has a different in their usage, and it is possible to use both provider and preset at the same time
+As you may notice providers and presets are different in their usage, and it is possible to use both providers and presets at the same time.
 
 <code-group>
   <code-block label="index.vue" active>
@@ -158,7 +158,7 @@ Genererate `<noscript>` tag for browsers that aren’t running javascript.
 
 ## `legacy`
 
-Using `nuxt-image` you should provider `width` and `height` for the component. These values are used to optimize image size and prevent [Cumulative Layout Shift](https://web.dev/cls/). But there are situation that we don't want to specify with and height for image. In this situations you can use `legacy` prop.  
+Using `nuxt-image` you should provider `width` and `height` for the component. These values are used to optimize image size and prevent [Cumulative Layout Shift](https://web.dev/cls/). But there are situations that we don't want to specify width and height for image. In these situations you can use `legacy` prop.
 
 Legacy mode is just and `<img>` tag with `srcsets`, no fixed size and no lazy loading.
 
@@ -209,7 +209,7 @@ Legacy mode is just and `<img>` tag with `srcsets`, no fixed size and no lazy lo
 ## `sets`
 
 The `sets` attribute specifies the URL of the image to use in different situations. With `sets`, the browser does the work of figuring out which image is best to load and render.  
-In `nuxt-image` you can simply provide various sizes and width breakpoints to generate `srcset`. Resized images are automatically create from image `src`.  
+In `nuxt-image` you can simply provide various sizes and width breakpoints to generate `srcset`. Resized images are automatically created from the image `src`.
 
 A set is consists of `width` and `breakpoint` or `media`: 
 - `width`: Width of generated image for this set
@@ -313,7 +313,7 @@ There are five standard values you can use with this property.
 
 ## `operations`
 
-In addition of standard operation, every provider can have their own operation. For example cloudinary supports lots of [transformations](https://cloudinary.com/documentation/image_transformations), Using `operations` prop you can use these transformations.  
+In addition of standard operation, every provider can have their own operation. For example cloudinary supports lots of [transformations](https://cloudinary.com/documentation/image_transformations). Using `operations` prop you can use these transformations.
 
 <code-group>
   <code-block label="index.vue" active>

--- a/docs/content/en/nuxt-picture.md
+++ b/docs/content/en/nuxt-picture.md
@@ -9,9 +9,9 @@ If you want to use modern and optimized formats like `webp` or `avif` and suppor
 
 The usage of `nuxt-picture` is same as `nuxt-image`, with a little differences:
 
-- When you use moders formats like `webp` in the component, a fallback image with `jpeg` format will generated and uses a fallback images for old browsers.
+- When you use modern formats like `webp` in the component, a fallback image with `jpeg` format will be generated and used as a fallback image for old browsers.
 
-- In `sets` prop you can define different format for each set. Defining different formats will help to improve browser compatibity.
+- In `sets` prop you can define different formats for each set. Defining different formats will help to improve browser compatibity.
   - If format does not present in a set it means that the set uses `format` props.
   - If format does not present in a set and `format` props is missing then image format will not change.
 

--- a/docs/content/en/options.md
+++ b/docs/content/en/options.md
@@ -65,7 +65,7 @@ See:
 
 ## `presets`
 
-Presets are collections of pre-defined configuration for your projects. Presets will help you to unify images all over your project.
+Presets are collections of pre-defined configurations for your projects. Presets will help you to unify images all over your project.
 
 <code-group>
   <code-block label="nuxt.config.js" active>

--- a/docs/content/en/providers.md
+++ b/docs/content/en/providers.md
@@ -11,7 +11,7 @@ Complete list of internal providers.
 
 Local provider is an integration of ipx and image module. Local provider is an specific provider that uses for development, optimizing in-project.  
 By default local provider looks `static` dir to find original images, You can change `dir` inside `nuxt.config`.
-The local provider has a chaching stategy to clear cached images to reduce massive disk usages. You can schedule the cache cleaning job using `clearCache` option in provide options. By default this cron job is disabled.
+The local provider has a caching stategy to clear cached images to reduce massive disk usages. You can schedule the cache cleaning job using `clearCache` option in provide options. By default this cron job is disabled.
 
 ```js{}[nuxt.config.js]
 export default {


### PR DESCRIPTION
Hello 👋 
I noticed a few typos as I was reading through the documentation, so I thought I'd suggest some fixes. Please let me know if any of my proposed changes don't align with the original intention and I'll gladly edit them 🙂 