### PR TITLE
docs: add back quote to imgix

### DIFF
--- a/docs/content/en/providers.md
+++ b/docs/content/en/providers.md
@@ -78,7 +78,7 @@ export default {
 }
 ```
 
-## 'imgix'
+## `imgix`
 
 Integration between [imgix](https://docs.imgix.com/) and the image module. To use this provider you just need to specify the base url of your service in imgix.
 


### PR DESCRIPTION
adding back quotes to imgix to match styling of other image provider titles in docs