### PR TITLE
feat: add module option to modify `IntersectionObserver` options

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -31,6 +31,9 @@ export default {
       imgix: {
         baseURL: 'https://assets.imgix.net'
       }
+    },
+    intersectOptions: {
+      rootMargin: '50px'
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ function imageModule (moduleOptions: ModuleOptions) {
 
   const options: ModuleOptions = {
     presets: [],
+    intersectOptions: {},
     ...nuxt.options.image,
     ...moduleOptions
   }
@@ -52,6 +53,7 @@ function imageModule (moduleOptions: ModuleOptions) {
 
   const pluginOptions = {
     defaultProvider: options.defaultProvider,
+    intersectOptions: options.intersectOptions,
     imports: {} as { [name: string]: string },
     providers: [] as { name: string, import: string, options: any }[],
     presets: options.presets

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -124,7 +124,7 @@ function createObserver (options: object) {
     rootMargin: '50px',
     ...options
   }
-  const observer = (typeof IntersectionObserver != "undefined" ? new IntersectionObserver(callback, intersectOptions) : {}) as IntersectionObserver
+  const observer = (typeof IntersectionObserver !== 'undefined' ? new IntersectionObserver(callback, intersectOptions) : {}) as IntersectionObserver
   const elementCallbackMap = {}
   function callback (entries, imgObserver) {
     entries.forEach((entry) => {

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -15,7 +15,7 @@ function processSource (src: string) {
   }
 }
 
-export function createImage (context, { providers, defaultProvider, presets }: CreateImageOptions) {
+export function createImage (context, { providers, defaultProvider, presets, intersectOptions }: CreateImageOptions) {
   const presetMap = presets.reduce((map, preset) => {
     map[preset.name] = preset
     return map
@@ -88,13 +88,17 @@ export function createImage (context, { providers, defaultProvider, presets }: C
     }
   })
 
-  image.$observer = createObserver()
+  image.$observer = createObserver(intersectOptions)
 
   return image
 }
 
-function createObserver () {
-  const observer = (process.client ? new IntersectionObserver(callback) : {}) as IntersectionObserver
+function createObserver (options: object) {
+  const intersectOptions = {
+    rootMargin: '50px',
+    ...options
+  }
+  const observer = (process.client ? new IntersectionObserver(callback, intersectOptions) : {}) as IntersectionObserver
   const elementCallbackMap = {}
   function callback (entries, imgObserver) {
     entries.forEach((entry) => {

--- a/templates/plugin.js
+++ b/templates/plugin.js
@@ -5,6 +5,7 @@ import { createImage } from '~image/image'
 
 <%=Object.entries(options.imports).map(([name, path]) => `import ${name} from '${path}'`).join('\n')%>
 
+const intersectOptions = <%= devalue(options.intersectOptions) %>
 const defaultProvider = '<%= options.defaultProvider %>'
 const presets = <%= devalue(options.presets) %>
 const providers = {}
@@ -25,6 +26,7 @@ export default function (context, inject) {
     defaultProvider,
     providers,
     presets,
+    intersectOptions
   })
 
   inject('img', image)

--- a/types/module.d.ts
+++ b/types/module.d.ts
@@ -11,7 +11,7 @@ export interface ModuleOptions {
     }
     [name: string]: any
   }
-  provider: object;
+  intersectOptions: object;
 }
 
 export const imageModule: Module<ModuleOptions>

--- a/types/runtime.d.ts
+++ b/types/runtime.d.ts
@@ -9,6 +9,7 @@ export interface CreateImageOptions {
   }
   presets: ImagePreset[]
   defaultProvider: string
+  intersectOptions: object
 }
 
 export interface $Image {


### PR DESCRIPTION
As Josh described in #39 We sould eager load images below viewport by using proper value for `rootMargin`.   
This PR introduces a module option called `intersectOptions` to customize `IntersectionObserver`