### PR TITLE
feat(runtime): catch image exceptions and prevent page crash

### DIFF
--- a/playground/layouts/default.vue
+++ b/playground/layouts/default.vue
@@ -10,5 +10,6 @@ body {
   background: #111111;
   display: flex;
   flex-direction: column;
+  color: #ffffff;
 }
 </style>

--- a/src/runtime/nuxt-image-mixins.ts
+++ b/src/runtime/nuxt-image-mixins.ts
@@ -149,7 +149,7 @@ export default {
       try {
         return this.$img.lqip(this.src)
       } catch (e) {
-        this.error = e.message
+        this.onError(e)
         return false
       }
     },
@@ -164,7 +164,8 @@ export default {
         })
         return encodeURI(image)
       } catch (e) {
-        this.error = e.message
+        this.onError(e)
+        return ''
       }
     },
     loadOriginalImage () {
@@ -180,6 +181,11 @@ export default {
         ...this.imgAttributes,
         ...extraAttributes
       })
+    },
+    onError (e: Error) {
+      this.error = e.message
+      // eslint-disable-next-line no-console
+      console.error(e.message)
     }
   },
   beforeDestroy () {

--- a/src/runtime/nuxt-image-mixins.ts
+++ b/src/runtime/nuxt-image-mixins.ts
@@ -65,6 +65,7 @@ export default {
   },
   data () {
     return {
+      error: '',
       srcset: [],
       blurry: null,
       loading: false,
@@ -73,7 +74,7 @@ export default {
   },
   async fetch () {
     if (!this.legacy) {
-      this.blurry = await this.$img.lqip(this.src)
+      this.blurry = await this.getPlaceholder()
     }
   },
   mounted () {
@@ -132,7 +133,7 @@ export default {
   },
   watch: {
     async src () {
-      this.blurry = await this.$img.lqip(this.src)
+      this.blurry = await this.getPlaceholder()
       this.original = null
       if (!this.legacy) {
         this.$img.$observer.remove(this.$el)
@@ -144,15 +145,27 @@ export default {
     }
   },
   methods: {
+    getPlaceholder () {
+      try {
+        return this.$img.lqip(this.src)
+      } catch (e) {
+        this.error = e.message
+        return false
+      }
+    },
     generateSizedImage (width: number, height: number, format: string) {
-      const image = this.$img(this.src, {
-        width,
-        height,
-        format,
-        fit: this.fit,
-        ...this.operations
-      })
-      return encodeURI(image)
+      try {
+        const image = this.$img(this.src, {
+          width,
+          height,
+          format,
+          fit: this.fit,
+          ...this.operations
+        })
+        return encodeURI(image)
+      } catch (e) {
+        this.error = e.message
+      }
     },
     loadOriginalImage () {
       this.loading = true

--- a/src/runtime/nuxt-image.ts
+++ b/src/runtime/nuxt-image.ts
@@ -23,6 +23,11 @@ export default {
     }
   },
   render (h) {
+    if (this.error) {
+      return h('div', {
+        class: ['__nim_w'].concat(this.$attrs.class || '')
+      }, [this.error])
+    }
     if (this.legacy) {
       return this.renderLegacy(h)
     }

--- a/src/runtime/nuxt-picture.ts
+++ b/src/runtime/nuxt-picture.ts
@@ -26,6 +26,11 @@ export default {
     }
   },
   render (h) {
+    if (this.error) {
+      return h('div', {
+        class: ['__nim_w'].concat(this.$attrs.class || '')
+      }, [this.error])
+    }
     if (this.legacy) {
       return this.renderLegacy(h)
     }


### PR DESCRIPTION
Doing wrong with `nuxt-image` should not lead page crash. When the user uses an invalid provider or preset Image module throw an exception, We need to catch these exceptions to prevent page crash.  
Instead we can show the exception message inside `nuxt-image`.

<img width="1027" alt="Screen Shot 2020-10-19 at 12 58 57 PM" src="https://user-images.githubusercontent.com/2047945/96426995-de17b280-120a-11eb-9bea-3d61bef4457a.png">
