### PR TITLE
feat: universal meta resolving

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "defu": "^3.1.0",
     "hasha": "^5.2.2",
-    "image-size": "^0.9.3",
+    "image-meta": "^0.0.1",
     "ipx": "0.4.0-rc.1",
     "node-fetch": "^2.6.1",
     "upath": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "hasha": "^5.2.2",
     "image-meta": "^0.0.1",
     "ipx": "0.4.0-rc.1",
+    "make-fetch-happen": "^8.0.10",
     "node-fetch": "^2.6.1",
     "upath": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "defu": "^3.1.0",
     "hasha": "^5.2.2",
+    "image-size": "^0.9.3",
     "ipx": "0.4.0-rc.1",
     "node-fetch": "^2.6.1",
     "upath": "^2.0.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,6 @@ function handleStaticGeneration (nuxt: any) {
 
   nuxt.hook('generate:done', async () => {
     const { port } = nuxt.server.listeners[0]
-    console.log("345678", nuxt.server.listeners[0])
     const { dir: generateDir } = nuxt.options.generate
     const host = 'http://localhost:' + port
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,12 @@ function imageModule (moduleOptions: ModuleOptions) {
   nuxt.hook('generate:before', () => {
     handleStaticGeneration(nuxt)
   })
+
+  const LruCache = require('lru-cache')
+  const cache = new LruCache()
+  nuxt.hook('vue-renderer:context', (ssrContext) => {
+    ssrContext.cache = cache
+  })
 }
 
 function loadProvider (key: string, provider: any) {
@@ -117,6 +123,7 @@ function handleStaticGeneration (nuxt: any) {
 
   nuxt.hook('generate:done', async () => {
     const { port } = nuxt.server.listeners[0]
+    console.log("345678", nuxt.server.listeners[0])
     const { dir: generateDir } = nuxt.options.generate
     const host = 'http://localhost:' + port
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ function loadProvider (key: string, provider: any) {
 function handleStaticGeneration (nuxt: any) {
   const staticImages = {} // url ~> hash
 
-  nuxt.hook('vue-renderer:ssr:prepareContext', async (renderContext) => {
+  nuxt.hook('vue-renderer:ssr:prepareContext', (renderContext) => {
     renderContext.mapImage = ({ url, isStatic, format, src }) => {
       if (!isStatic) {
         return url

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,7 +102,7 @@ function loadProvider (key: string, provider: any) {
 function handleStaticGeneration (nuxt: any) {
   const staticImages = {} // url ~> hash
 
-  nuxt.hook('vue-renderer:ssr:prepareContext', (renderContext) => {
+  nuxt.hook('vue-renderer:ssr:prepareContext', async (renderContext) => {
     renderContext.mapImage = ({ url, isStatic, format, src }) => {
       if (!isStatic) {
         return url

--- a/src/providers/fastly/runtime.ts
+++ b/src/providers/fastly/runtime.ts
@@ -1,6 +1,5 @@
 import { RuntimeProvider, ImageModifiers } from 'types'
 import { cleanDoubleSlashes, createOperationsGenerator } from '~image/utils'
-import fetch from '~image/fetch'
 
 const operationsGenerator = createOperationsGenerator({
   valueMap: {
@@ -21,17 +20,7 @@ export default <RuntimeProvider> {
     const operations = operationsGenerator(modifiers)
     const url = cleanDoubleSlashes(options.baseURL + src + '?' + operations)
     return {
-      url,
-      getInfo: async () => {
-        const infoString = await fetch(url).then(res => res.headers.get('fastly-io-info') || '')
-        const info = Object.fromEntries(infoString.split(' ').map(part => part.split('=')))
-        const [width, height] = (info.idim || '').split('x').map(p => parseInt(p, 10))
-        return {
-          width,
-          height,
-          bytes: info.ifsz
-        }
-      }
+      url
     }
   }
 }

--- a/src/providers/imgix/runtime.ts
+++ b/src/providers/imgix/runtime.ts
@@ -1,6 +1,5 @@
 import { RuntimeProvider, ImageModifiers } from 'types'
 import { cleanDoubleSlashes, createOperationsGenerator } from '~image/utils'
-import fetch from '~image/fetch'
 
 const operationsGenerator = createOperationsGenerator({
   keyMap: {
@@ -26,15 +25,7 @@ export default <RuntimeProvider> {
     const operations = operationsGenerator(modifiers)
     const url = cleanDoubleSlashes(options.baseURL + src + '?' + operations)
     return {
-      url,
-      getInfo: async () => {
-        const info = await fetch(url + '&fm=json').then(res => res.json())
-        return {
-          width: info.PixelWidth,
-          height: info.PixelHeight,
-          bytes: info['Content-Length']
-        }
-      }
+      url
     }
   }
 }

--- a/src/providers/local/runtime.ts
+++ b/src/providers/local/runtime.ts
@@ -1,13 +1,12 @@
 import { RuntimeProvider, ImageModifiers } from 'types'
 import { cleanDoubleSlashes } from '~image/utils'
-import fetch from '~image/fetch'
 
 function predictAdapter (src: string) {
   return src.match(/^https?:\/\//) ? 'remote' : 'local'
 }
 
 export default <RuntimeProvider> {
-  getImage (src: string, modifiers: ImageModifiers, options: any) {
+  getImage (src: string, modifiers: ImageModifiers, _options: any) {
     const operations = []
 
     const fit = modifiers.fit ? `_${modifiers.fit}` : ''
@@ -23,24 +22,10 @@ export default <RuntimeProvider> {
 
     const operationsString = operations.join(',') || '_'
     const url = cleanDoubleSlashes(`/_image/local/${adapter}/${modifiers.format || '_'}/${operationsString}/${src}`)
-    const infoUrl = cleanDoubleSlashes(`/_image/local/${adapter}/${modifiers.format || 'jpg'}.json/${operationsString}_url/${src}`)
-
-    const baseURL = process.client ? options.baseURL : options.internalBaseURL
-
-    let _meta
-    const getMeta = () => _meta || fetch(baseURL + infoUrl).then(res => res.json())
 
     return {
       url,
-      isStatic: true,
-      async getInfo () {
-        const { width, height, size, data } = await getMeta()
-        return { width, height, bytes: size, placeholder: data }
-      },
-      async getPlaceHolder () {
-        const { data } = await getMeta()
-        return data
-      }
+      isStatic: true
     }
   }
 }

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -16,6 +16,22 @@ function processSource (src: string) {
   }
 }
 
+function getCache (context) {
+  if (!context.cache) {
+    if (context.ssrContext && context.ssrContext.cache) {
+      context.cache = context.ssrContext.cache
+    } else {
+      const _cache = {}
+      context.cache = {
+        get: id => _cache[id],
+        set: (id, value) => { _cache[id] = value },
+        has: id => typeof _cache[id] !== 'undefined'
+      }
+    }
+  }
+  return context.cache
+}
+
 export function createImage (context, { providers, defaultProvider, presets, intersectOptions }: CreateImageOptions) {
   const presetMap = presets.reduce((map, preset) => {
     map[preset.name] = preset
@@ -110,7 +126,7 @@ export function createImage (context, { providers, defaultProvider, presets, int
     } else {
       const baseUrl = 'http://localhost:3000'
       const absoluteUrl = sImage.url[0] === '/' ? baseUrl + sImage.url : sImage.url
-      Object.assign(meta, await getMeta(absoluteUrl))
+      Object.assign(meta, await getMeta(absoluteUrl, getCache(context)))
     }
 
     return meta

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -1,4 +1,5 @@
 import type { CreateImageOptions, ImageModifiers, ImagePreset } from 'types'
+import { getMeta } from './meta'
 
 function processSource (src: string) {
   if (!src.includes(':') || src.match('^https?://')) {
@@ -101,15 +102,20 @@ export function createImage (context, { providers, defaultProvider, presets, int
     const provider = getProvider(sourceProvider || options.provider || defaultProvider)
 
     const sImage = provider.provider.getImage(src, { ...modifiers, width: 30 }, provider.defaults)
-    const meta = { placeholder: sImage.url }
 
-    if (typeof sImage.getInfo === 'function') {
-      Object.assign(meta, await sImage.getInfo())
-    }
+    const meta = await { placeholder: sImage.url }
 
-    if (typeof sImage.getPlaceholder === 'function') {
-      meta.placeholder = await sImage.getPlaceholder()
-    }
+    const baseUrl = 'http://localhost:3000'
+    const absoluteUrl = sImage.url[0] === '/' ? baseUrl + sImage.url : sImage.url
+    Object.assign(meta, await getMeta(absoluteUrl))
+
+    // if (typeof sImage.getInfo === 'function') {
+    //   Object.assign(meta, await sImage.getInfo())
+    // }
+
+    // if (typeof sImage.getPlaceholder === 'function') {
+    //   meta.placeholder = await sImage.getPlaceholder()
+    // }
 
     return meta
   }

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -105,17 +105,13 @@ export function createImage (context, { providers, defaultProvider, presets, int
 
     const meta = await { placeholder: sImage.url }
 
-    const baseUrl = 'http://localhost:3000'
-    const absoluteUrl = sImage.url[0] === '/' ? baseUrl + sImage.url : sImage.url
-    Object.assign(meta, await getMeta(absoluteUrl))
-
-    // if (typeof sImage.getInfo === 'function') {
-    //   Object.assign(meta, await sImage.getInfo())
-    // }
-
-    // if (typeof sImage.getPlaceholder === 'function') {
-    //   meta.placeholder = await sImage.getPlaceholder()
-    // }
+    if (typeof sImage.getMeta === 'function') {
+      Object.assign(meta, await sImage.getMeta())
+    } else {
+      const baseUrl = 'http://localhost:3000'
+      const absoluteUrl = sImage.url[0] === '/' ? baseUrl + sImage.url : sImage.url
+      Object.assign(meta, await getMeta(absoluteUrl))
+    }
 
     return meta
   }

--- a/src/runtime/meta.ts
+++ b/src/runtime/meta.ts
@@ -1,0 +1,37 @@
+// export type ImageMeta {
+//   width: number;
+//   height: number;
+//   data: any;
+// }
+
+export async function getMeta (url) {
+  if (process.client) {
+    if (typeof Image === 'undefined') {
+      throw new TypeError('Image not supported')
+    }
+
+    return new Promise((resolve, reject) => {
+      const img = new Image()
+      img.onload = () => {
+        resolve({
+          width: img.width,
+          height: img.height,
+          placeholder: url
+        })
+      }
+      img.onerror = err => reject(err)
+      img.src = url
+    })
+  }
+
+  if (process.server) {
+    const imageMeta = await import('image-meta')
+    const data: Buffer = await fetch(url).then((res: any) => res.buffer())
+    const { width, height, mimeType } = await imageMeta(data)
+    return {
+      width,
+      height,
+      placeholder: `data:${mimeType};base64,${data.toString('base64')}`
+    }
+  }
+}

--- a/src/runtime/meta.ts
+++ b/src/runtime/meta.ts
@@ -25,7 +25,7 @@ export async function getMeta (url) {
   }
 
   if (process.server) {
-    const imageMeta = require('image-meta')
+    const imageMeta = require('image-meta').default
     const data: Buffer = await fetch(url).then((res: any) => res.buffer())
     const { width, height, mimeType } = await imageMeta(data)
     return {

--- a/src/runtime/meta.ts
+++ b/src/runtime/meta.ts
@@ -1,10 +1,6 @@
-// export type ImageMeta {
-//   width: number;
-//   height: number;
-//   data: any;
-// }
+import { RuntimeImageInfo } from 'types'
 
-export async function getMeta (url) {
+export async function getMeta (url): RuntimeImageInfo {
   if (process.client) {
     if (typeof Image === 'undefined') {
       throw new TypeError('Image not supported')

--- a/src/runtime/meta.ts
+++ b/src/runtime/meta.ts
@@ -25,7 +25,7 @@ export async function getMeta (url) {
   }
 
   if (process.server) {
-    const imageMeta = await import('image-meta')
+    const imageMeta = require('image-meta')
     const data: Buffer = await fetch(url).then((res: any) => res.buffer())
     const { width, height, mimeType } = await imageMeta(data)
     return {

--- a/src/runtime/meta.ts
+++ b/src/runtime/meta.ts
@@ -1,6 +1,11 @@
 import { RuntimeImageInfo } from 'types'
 
-export async function getMeta (url): RuntimeImageInfo {
+export async function getMeta (url, cache): RuntimeImageInfo {
+  const cacheKey = 'image:meta:' + url
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey)
+  }
+
   if (process.client) {
     if (typeof Image === 'undefined') {
       throw new TypeError('Image not supported')
@@ -9,11 +14,13 @@ export async function getMeta (url): RuntimeImageInfo {
     return new Promise((resolve, reject) => {
       const img = new Image()
       img.onload = () => {
-        resolve({
+        const meta = {
           width: img.width,
           height: img.height,
           placeholder: url
-        })
+        }
+        cache.set(cacheKey, meta)
+        resolve(meta)
       }
       img.onerror = err => reject(err)
       img.src = url
@@ -24,10 +31,12 @@ export async function getMeta (url): RuntimeImageInfo {
     const imageMeta = require('image-meta').default
     const data: Buffer = await fetch(url).then((res: any) => res.buffer())
     const { width, height, mimeType } = await imageMeta(data)
-    return {
+    const meta = {
       width,
       height,
       placeholder: `data:${mimeType};base64,${data.toString('base64')}`
     }
+    cache.set(cacheKey, meta)
+    return meta
   }
 }

--- a/src/runtime/nuxt-image-mixins.ts
+++ b/src/runtime/nuxt-image-mixins.ts
@@ -24,7 +24,7 @@ export default {
     },
     lazy: {
       type: Boolean,
-      default: typeof IntersectionObserver !== 'undefined'
+      default: true
     },
     sets: {
       type: [String, Array],
@@ -88,7 +88,7 @@ export default {
         height: undefined,
         placeholder: undefined
       },
-      lazyState: LazyState.IDLE
+      lazyState: this.lazy ? LazyState.IDLE : LazyState.LOADED
     }
   },
   computed: {

--- a/src/runtime/nuxt-image-mixins.ts
+++ b/src/runtime/nuxt-image-mixins.ts
@@ -88,7 +88,7 @@ export default {
         height: undefined,
         placeholder: undefined
       },
-      lazyState: this.lazy ? LazyState.IDLE : LazyState.LOADED
+      lazyState: LazyState.IDLE
     }
   },
   computed: {
@@ -213,7 +213,7 @@ export default {
       }
     },
     loadOriginalImage () {
-      this.lazyState = 'loading'
+      this.lazyState = LazyState.LOADING
     },
     renderImgAttributesToString (extraAttributes = {}) {
       return renderAttributesToString({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "types": [
       "@nuxt/types",
       "@types/node",
+      "image-size",
       "./types"
     ],
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "types": [
       "@nuxt/types",
       "@types/node",
-      "image-size",
+      "image-meta",
       "./types"
     ],
     "paths": {

--- a/types/runtime.d.ts
+++ b/types/runtime.d.ts
@@ -55,8 +55,7 @@ export interface RuntimeProvider {
 export interface RuntimeImage {
   url: string,
   isStatic?: boolean,
-  getInfo?: () => Promise<RuntimeImageInfo>
-  getPlaceholder?: () => Promise<string>
+  getMeta?: () => Promise<RuntimeImageInfo>
 }
 
 export interface RuntimeImageInfo {
@@ -64,8 +63,6 @@ export interface RuntimeImageInfo {
   width: number,
   // height of image in pixels
   height: number,
-  // size of image in bytes
-  bytes?: number,
   // placeholder (base64 or url)
   placeholder?: string,
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6371,12 +6371,10 @@ ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-image-size@^0.9.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.9.3.tgz#f7efce6b0a1649b44b9bc43b9d9a5acf272264b6"
-  integrity sha512-5SakFa79uhUVSjKeQE30GVzzLJ0QNzB53+I+/VD1vIesD6GP6uatWIlgU0uisFNLt1u0d6kBydp7yfk+lLJhLQ==
-  dependencies:
-    queue "6.0.1"
+image-meta@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/image-meta/-/image-meta-0.0.1.tgz#0f6f708e6d68ea796a977dcae3223019ee2b3eca"
+  integrity sha512-FhTB6WW/zfswIFQwjItrisL/Pt/aKbMCAkVdDtdfsaWwo6QwhpM7XMdwtDw8qs5y2IZsHcQ7TPG/JznJYVphSg==
 
 import-cwd@^2.0.0:
   version "2.1.0"
@@ -10058,13 +10056,6 @@ querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
-
-queue@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.1.tgz#abd5a5b0376912f070a25729e0b6a7d565683791"
-  integrity sha512-AJBQabRCCNr9ANq8v77RJEv73DPbn55cdTb+Giq4X0AVnNVZvMHlYp7XlQiN+1npCZj1DuSmaA2hYVUUDgxFDg==
-  dependencies:
-    inherits "~2.0.3"
 
 quick-lru@^1.0.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6371,6 +6371,13 @@ ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+image-size@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.9.3.tgz#f7efce6b0a1649b44b9bc43b9d9a5acf272264b6"
+  integrity sha512-5SakFa79uhUVSjKeQE30GVzzLJ0QNzB53+I+/VD1vIesD6GP6uatWIlgU0uisFNLt1u0d6kBydp7yfk+lLJhLQ==
+  dependencies:
+    queue "6.0.1"
+
 import-cwd@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-cwd/-/import-cwd-2.1.0.tgz#aa6cf36e722761285cb371ec6519f53e2435b0a9"
@@ -10051,6 +10058,13 @@ querystring@0.2.0, querystring@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
+queue@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.1.tgz#abd5a5b0376912f070a25729e0b6a7d565683791"
+  integrity sha512-AJBQabRCCNr9ANq8v77RJEv73DPbn55cdTb+Giq4X0AVnNVZvMHlYp7XlQiN+1npCZj1DuSmaA2hYVUUDgxFDg==
+  dependencies:
+    inherits "~2.0.3"
 
 quick-lru@^1.0.0:
   version "1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,6 +1151,13 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@npmcli/move-file@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@npmcli/move-file/-/move-file-1.0.1.tgz#de103070dac0f48ce49cf6693c23af59c0f70464"
+  integrity sha512-Uv6h1sT+0DrblvIrolFtbvM1FgWm+/sy4B3pvLp67Zys+thcukzS5ekn7HsZFGpWP4Q3fYJCljbWQE/XivMRLw==
+  dependencies:
+    mkdirp "^1.0.4"
+
 "@nuxt/babel-preset-app-edge@2.14.7-26697638.61e93d01":
   version "2.14.7-26697638.61e93d01"
   resolved "https://registry.yarnpkg.com/@nuxt/babel-preset-app-edge/-/babel-preset-app-edge-2.14.7-26697638.61e93d01.tgz#08ab7bb3670a0a3da226ab49a855343ba7f2dbde"
@@ -1634,6 +1641,11 @@
   integrity sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==
   dependencies:
     defer-to-connect "^2.0.0"
+
+"@tootallnate/once@1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
+  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
 "@types/anymatch@*":
   version "1.3.1"
@@ -2460,6 +2472,15 @@ agent-base@6:
   dependencies:
     debug "4"
 
+agentkeepalive@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/agentkeepalive/-/agentkeepalive-4.1.3.tgz#360a09d743a1f4fde749f9ba07caa6575d08259a"
+  integrity sha512-wn8fw19xKZwdGPO47jivonaHRTd+nGOMP1z11sgGeQzDy2xd5FG0R67dIMcKHDE2cJ5y+YXV30XVGUBPRSY7Hg==
+  dependencies:
+    debug "^4.1.0"
+    depd "^1.1.2"
+    humanize-ms "^1.2.1"
+
 aggregate-error@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-3.1.0.tgz#92670ff50f5359bdb7a3e0d40d0ec30c5737687a"
@@ -3211,6 +3232,29 @@ cacache@^13.0.1:
     ssri "^7.0.0"
     unique-filename "^1.1.1"
 
+cacache@^15.0.0:
+  version "15.0.5"
+  resolved "https://registry.yarnpkg.com/cacache/-/cacache-15.0.5.tgz#69162833da29170d6732334643c60e005f5f17d0"
+  integrity sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==
+  dependencies:
+    "@npmcli/move-file" "^1.0.1"
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    glob "^7.1.4"
+    infer-owner "^1.0.4"
+    lru-cache "^6.0.0"
+    minipass "^3.1.1"
+    minipass-collect "^1.0.2"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.2"
+    mkdirp "^1.0.3"
+    p-map "^4.0.0"
+    promise-inflight "^1.0.1"
+    rimraf "^3.0.2"
+    ssri "^8.0.0"
+    tar "^6.0.2"
+    unique-filename "^1.1.1"
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -3458,6 +3502,11 @@ chownr@^1.1.1, chownr@^1.1.2:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
+
+chownr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
+  integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
 chrome-trace-event@^1.0.2:
   version "1.0.2"
@@ -4514,7 +4563,7 @@ delegates@^1.0.0:
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
 
-depd@~1.1.2:
+depd@^1.1.2, depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
@@ -4789,6 +4838,13 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
+encoding@^0.1.12:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
+  integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+  dependencies:
+    iconv-lite "^0.6.2"
+
 end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
@@ -4821,6 +4877,11 @@ entities@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
   integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
+
+err-code@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-1.1.2.tgz#06e0116d3028f6aef4806849eb0ea6a748ae6960"
+  integrity sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
 
 errno@^0.1.3, errno@~0.1.7:
   version "0.1.7"
@@ -6275,7 +6336,7 @@ htmlparser2@^3.3.0:
     inherits "^2.0.1"
     readable-stream "^3.1.1"
 
-http-cache-semantics@^4.0.0:
+http-cache-semantics@^4.0.0, http-cache-semantics@^4.0.4:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
@@ -6301,6 +6362,15 @@ http-errors@~1.7.2:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+http-proxy-agent@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz#8a8c8ef7f5932ccf953c296ca8291b95aa74aa3a"
+  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
+  dependencies:
+    "@tootallnate/once" "1"
+    agent-base "6"
+    debug "4"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -6337,12 +6407,26 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+humanize-ms@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
+  integrity sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
+  dependencies:
+    ms "^2.0.0"
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
+
+iconv-lite@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.2.tgz#ce13d1875b0c3a674bd6a04b7f76b01b1b6ded01"
+  integrity sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3.0.0"
 
 icss-utils@^4.0.0, icss-utils@^4.1.1:
   version "4.1.1"
@@ -6747,6 +6831,11 @@ is-invalid-path@^0.1.0:
   integrity sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=
   dependencies:
     is-glob "^2.0.0"
+
+is-lambda@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-lambda/-/is-lambda-1.0.1.tgz#3d9877899e6a53efc0160504cde15f82e6f061d5"
+  integrity sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=
 
 is-module@^1.0.0:
   version "1.0.0"
@@ -7844,6 +7933,13 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 magic-string@^0.25.5, magic-string@^0.25.7:
   version "0.25.7"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
@@ -7877,6 +7973,27 @@ make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
+make-fetch-happen@^8.0.10:
+  version "8.0.10"
+  resolved "https://registry.yarnpkg.com/make-fetch-happen/-/make-fetch-happen-8.0.10.tgz#f37c5d93d14290488ca6a2ae917a380bd7d24f16"
+  integrity sha512-jPLPKQjBmDLK5r1BdyDyNKBytmkv2AsDWm2CxHJh+fqhSmC9Pmb7RQxwOq8xQig9+AWIS49+51k4f6vDQ3VnrQ==
+  dependencies:
+    agentkeepalive "^4.1.0"
+    cacache "^15.0.0"
+    http-cache-semantics "^4.0.4"
+    http-proxy-agent "^4.0.1"
+    https-proxy-agent "^5.0.0"
+    is-lambda "^1.0.1"
+    lru-cache "^6.0.0"
+    minipass "^3.1.3"
+    minipass-collect "^1.0.2"
+    minipass-fetch "^1.3.0"
+    minipass-flush "^1.0.5"
+    minipass-pipeline "^1.2.2"
+    promise-retry "^1.1.1"
+    socks-proxy-agent "^5.0.0"
+    ssri "^8.0.0"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -8187,6 +8304,17 @@ minipass-collect@^1.0.2:
   dependencies:
     minipass "^3.0.0"
 
+minipass-fetch@^1.3.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/minipass-fetch/-/minipass-fetch-1.3.2.tgz#573766fb1ae86e30df916a6b060bc2e801bf8f37"
+  integrity sha512-/i4fX1ss+Dtwyk++OsAI6SEV+eE1dvI6W+0hORdjfruQ7VD5uYTetJIHcEMjWiEiszWjn2aAtP1CB/Q4KfeoYA==
+  dependencies:
+    minipass "^3.1.0"
+    minipass-sized "^1.0.3"
+    minizlib "^2.0.0"
+  optionalDependencies:
+    encoding "^0.1.12"
+
 minipass-flush@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/minipass-flush/-/minipass-flush-1.0.5.tgz#82e7135d7e89a50ffe64610a787953c4c4cbb373"
@@ -8201,11 +8329,26 @@ minipass-pipeline@^1.2.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^3.0.0, minipass@^3.1.1:
+minipass-sized@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/minipass-sized/-/minipass-sized-1.0.3.tgz#70ee5a7c5052070afacfbc22977ea79def353b70"
+  integrity sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==
+  dependencies:
+    minipass "^3.0.0"
+
+minipass@^3.0.0, minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-3.1.3.tgz#7d42ff1f39635482e15f9cdb53184deebd5815fd"
   integrity sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
   dependencies:
+    yallist "^4.0.0"
+
+minizlib@^2.0.0, minizlib@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-2.1.2.tgz#e90d3466ba209b932451508a11ce3d3632145931"
+  integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+  dependencies:
+    minipass "^3.0.0"
     yallist "^4.0.0"
 
 mississippi@^3.0.0:
@@ -8244,7 +8387,7 @@ mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@^0.5.3, mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.5"
 
-mkdirp@^1.0.4:
+mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -8288,7 +8431,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@2.1.2:
+ms@2.1.2, ms@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -8821,6 +8964,13 @@ p-map@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-3.0.0.tgz#d704d9af8a2ba684e2600d9a215983d4141a979d"
   integrity sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==
+  dependencies:
+    aggregate-error "^3.0.0"
+
+p-map@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-4.0.0.tgz#bb2f95a5eda2ec168ec9274e06a747c3e2904d2b"
+  integrity sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
   dependencies:
     aggregate-error "^3.0.0"
 
@@ -9917,6 +10067,14 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
+promise-retry@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/promise-retry/-/promise-retry-1.1.1.tgz#6739e968e3051da20ce6497fb2b50f6911df3d6d"
+  integrity sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=
+  dependencies:
+    err-code "^1.0.0"
+    retry "^0.10.0"
+
 prompts@^2.0.1:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.3.2.tgz#480572d89ecf39566d2bd3fe2c9fccb7c4c0b068"
@@ -10509,6 +10667,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+retry@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
+  integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
+
 retry@^0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
@@ -10639,7 +10802,7 @@ safe-regex@^2.1.1:
   dependencies:
     regexp-tree "~0.1.1"
 
-"safer-buffer@>= 2.1.2 < 3", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
+"safer-buffer@>= 2.1.2 < 3", "safer-buffer@>= 2.1.2 < 3.0.0", safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
@@ -10956,6 +11119,11 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+smart-buffer@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
+  integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -10985,6 +11153,23 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+socks-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz#7c0f364e7b1cf4a7a437e71253bed72e9004be60"
+  integrity sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+    socks "^2.3.3"
+
+socks@^2.3.3:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.5.0.tgz#3a7c286db114f67864a4bd8b4207a91d1db3d6db"
+  integrity sha512-00OqQHp5SCbwm9ecOMJj9aQtMSjwi1uVuGQoxnpKCS50VKZcOZ8z11CTKypmR8sEy7nZimy/qXY7rYJYbRlXmA==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "^4.1.0"
 
 sort-keys@^1.0.0:
   version "1.1.2"
@@ -11151,6 +11336,13 @@ ssri@^7.0.0:
   integrity sha512-77/WrDZUWocK0mvA5NTRQyveUf+wsrIc6vyrxpS8tVvYBcX215QbafrJR3KtkpskIzoFLqqNuuYQvxaMjXJ/0g==
   dependencies:
     figgy-pudding "^3.5.1"
+    minipass "^3.1.1"
+
+ssri@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-8.0.0.tgz#79ca74e21f8ceaeddfcb4b90143c458b8d988808"
+  integrity sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==
+  dependencies:
     minipass "^3.1.1"
 
 stable@^0.1.8:
@@ -11542,6 +11734,18 @@ tar-stream@^2.0.0:
     fs-constants "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^3.1.1"
+
+tar@^6.0.2:
+  version "6.0.5"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.5.tgz#bde815086e10b39f1dcd298e89d596e1535e200f"
+  integrity sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==
+  dependencies:
+    chownr "^2.0.0"
+    fs-minipass "^2.0.0"
+    minipass "^3.0.0"
+    minizlib "^2.1.1"
+    mkdirp "^1.0.3"
+    yallist "^4.0.0"
 
 term-size@^2.1.0:
   version "2.2.0"


### PR DESCRIPTION
Previously we was depending on providers to resolve image meta (getting aspect ratio and also base64) this was adding complexity and sometimes extera requests. With this PR, using [nuxt-contrib/image-meta](https://github.com/nuxt-contrib/image-meta) (for Node.js) and `Image` + `Canvas` (for Browser), we can universally have ratio. (Future release of `image-meta` may eventually support Node.js if we can remove Buffer dependency)