### PR TITLE
refactor image utility

### DIFF
--- a/docs/content/en/providers.md
+++ b/docs/content/en/providers.md
@@ -23,10 +23,6 @@ export default {
          **/
         baseURL: 'https://awesome.com/',
         /**
-         * Internal address of your website 
-         **/
-        internalBaseURL: 'http://192.168.1.100:3000/',
-        /**
          * Input directory for images
          **/
         dir: '~/static',

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -1,5 +1,6 @@
 export default {
   components: true,
+  target: 'static',
   modules: [
     '../src/index.ts'
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra'
 import upath from 'upath'
 import { ModuleOptions, ProviderFactory } from 'types'
 import { downloadImage, getFileExtension, hash, tryRequire } from './utils'
+import { cleanDoubleSlashes } from './runtime/utils'
 export type { Provider, RuntimeProvider } from 'types'
 
 function imageModule (moduleOptions: ModuleOptions) {
@@ -12,6 +13,7 @@ function imageModule (moduleOptions: ModuleOptions) {
   const options: ModuleOptions = {
     presets: [],
     intersectOptions: {},
+    sizes: [320, 420, 768, 1024, 1200],
     providers: {},
     ...nuxt.options.image,
     ...moduleOptions
@@ -36,6 +38,7 @@ function imageModule (moduleOptions: ModuleOptions) {
     .map(([key, provider]) => loadProvider.call(this, key, provider))
 
   const pluginOptions = {
+    sizes: options.sizes,
     defaultProvider: options.defaultProvider,
     intersectOptions: options.intersectOptions,
     imports: {} as { [name: string]: string },
@@ -73,14 +76,21 @@ function imageModule (moduleOptions: ModuleOptions) {
   nuxt.options.build.transpile.push(runtimeDir)
 
   nuxt.hook('generate:before', () => {
-    handleStaticGeneration(nuxt)
+    handleStaticGeneration(nuxt, options)
   })
 
   const LruCache = require('lru-cache')
   const cache = new LruCache()
   nuxt.hook('vue-renderer:context', (ssrContext) => {
     ssrContext.cache = cache
+    ssrContext.internalUrl = options.internalUrl
   })
+
+  if (typeof nuxt.listen === 'function') {
+    nuxt.listen(0).then((server) => {
+      options.internalUrl = `http://localhost:${server.port}`
+    })
+  }
 }
 
 function loadProvider (key: string, provider: any) {
@@ -105,10 +115,11 @@ function loadProvider (key: string, provider: any) {
   return provider
 }
 
-function handleStaticGeneration (nuxt: any) {
+function handleStaticGeneration (nuxt: any, options: ModuleOptions) {
   const staticImages = {} // url ~> hash
 
   nuxt.hook('vue-renderer:ssr:prepareContext', (renderContext) => {
+    renderContext.isGenerating = true
     renderContext.mapImage = ({ url, isStatic, format, src }) => {
       if (!isStatic) {
         return url
@@ -122,16 +133,13 @@ function handleStaticGeneration (nuxt: any) {
   })
 
   nuxt.hook('generate:done', async () => {
-    const { port } = nuxt.server.listeners[0]
     const { dir: generateDir } = nuxt.options.generate
-    const host = 'http://localhost:' + port
-
     try { await fs.mkdir(path.join(generateDir, '_image')) } catch {}
 
     const downloads = Object.entries(staticImages)
       .map(([url, name]) => {
         if (!url.startsWith('http')) {
-          url = host + url
+          url = cleanDoubleSlashes(options.internalUrl + url)
         }
         return downloadImage({
           url,
@@ -168,7 +176,6 @@ function prepareLocalProvider ({ nuxt, options }, providerOptions) {
 
   providerOptions = defu(providerOptions, {
     baseURL: `http://${defaultHost}:${defaultPort}${prefix}`,
-    internalBaseURL: `http://${defaultHost}:${defaultPort}${prefix}`,
     dir: path.resolve(nuxt.options.srcDir, nuxt.options.dir.static)
   })
 

--- a/src/providers/local/index.ts
+++ b/src/providers/local/index.ts
@@ -5,8 +5,7 @@ export default <ProviderFactory> function (providerOptions) {
   return {
     runtime: require.resolve('./runtime'),
     runtimeOptions: {
-      baseURL: providerOptions.baseURL,
-      internalBaseURL: providerOptions.internalBaseURL
+      baseURL: providerOptions.baseURL
     },
     middleware: createMiddleware(providerOptions)
   }

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -1,5 +1,6 @@
-import type { CreateImageOptions, ImageModifiers, ImagePreset } from 'types'
+import type { CreateImageOptions, ImageModifiers, ImagePreset, ImageSize } from 'types'
 import { getMeta } from './meta'
+import { cleanDoubleSlashes } from './utils'
 
 function processSource (src: string) {
   if (!src.includes(':') || src.match('^https?://')) {
@@ -32,7 +33,7 @@ function getCache (context) {
   return context.cache
 }
 
-export function createImage (context, { providers, defaultProvider, presets, intersectOptions }: CreateImageOptions) {
+export function createImage (context, { providers, defaultProvider, presets, intersectOptions, responsiveSizes }: CreateImageOptions) {
   const presetMap = presets.reduce((map, preset) => {
     map[preset.name] = preset
     return map
@@ -56,7 +57,7 @@ export function createImage (context, { providers, defaultProvider, presets, int
     return presetMap[name]
   }
 
-  function image (source: string, modifiers: ImageModifiers, options: any = {}) {
+  function parseImage (source: string, modifiers: ImageModifiers, options: any = {}) {
     const { src, provider: sourceProvider, preset: sourcePreset } = processSource(source)
     const provider = getProvider(sourceProvider || options.provider || defaultProvider)
     const preset = getPreset(sourcePreset || options.preset)
@@ -66,18 +67,41 @@ export function createImage (context, { providers, defaultProvider, presets, int
       preset ? preset.modifiers : modifiers,
       { ...provider.defaults, ...options }
     )
+    return {
+      src,
+      provider,
+      preset,
+      image
+    }
+  }
+
+  function image (source: string, modifiers: ImageModifiers, options: any = {}) {
+    const { src, image } = parseImage(source, modifiers, options)
     const { url: providerUrl, isStatic } = image
 
+    /**
+     * Handle full static render
+     */
     // @ts-ignore
     if (typeof window !== 'undefined' && typeof window.$nuxt._pagePayload !== 'undefined') {
       // @ts-ignore
       const jsonPData = window.$nuxt._pagePayload.data[0]
-      if (jsonPData.images[providerUrl]) {
+      if (jsonPData.nuxtImageMap[providerUrl]) {
         // Hydration with hash
-        return jsonPData.images[providerUrl]
+        image.url = jsonPData.nuxtImageMap[providerUrl]
+      } else if (image.isStatic) {
+        image.url = src
       }
       // return original source on cache fail in full static mode
-      return src
+      return image
+    }
+
+    /**
+     * Handle client side rendering without server
+     */
+    if (typeof window !== 'undefined' && context.isStatic && image.isStatic) {
+      image.url = src
+      return image
     }
 
     const nuxtState = context.nuxtState || context.ssrContext.nuxt
@@ -85,25 +109,19 @@ export function createImage (context, { providers, defaultProvider, presets, int
       nuxtState.data = [{}]
     }
     const data = nuxtState.data[0]
-    data.images = data.images || {}
-
-    let url = providerUrl
-    if (data.images[url]) {
+    data.nuxtImageMap = data.nuxtImageMap || {}
+    const url = providerUrl
+    if (data.nuxtImageMap[url]) {
       // Hydration with hash
-      url = data.images[url]
+      image.url = data.nuxtImageMap[url]
     } else if (context.ssrContext && typeof context.ssrContext.mapImage === 'function') {
       // Full Static
-      const originalURL = url
-      url = context.ssrContext.mapImage({ url, isStatic, format: modifiers.format, src })
-
-      if (url) {
-        data.images[providerUrl] = url
-      } else {
-        url = originalURL
+      const mappedUrl = context.ssrContext.mapImage({ url, isStatic, format: modifiers.format, src })
+      if (mappedUrl) {
+        image.url = data.nuxtImageMap[providerUrl] = mappedUrl
       }
     }
-
-    return url
+    return image
   }
 
   presets.forEach((preset) => {
@@ -113,19 +131,57 @@ export function createImage (context, { providers, defaultProvider, presets, int
       })
     }
   })
+
+  image.sizes = (src: string, sizes: Array<ImageSize> | string, operations: any = {}) => {
+    if (typeof sizes === 'string') {
+      sizes = sizes
+        .split(',')
+        .map(set => set.match(/((\d+):)?(\d+)\s*(\((\w+)\))?/))
+        .filter(match => !!match)
+        .map((match, index) => ({
+          width: match[3],
+          breakpoint: match[2] || (index > 0 && match[3]),
+          format: match[5] || operations.format
+        }))
+    }
+    if ((!Array.isArray(sizes) || !sizes.length)) {
+      sizes = responsiveSizes.map(width => ({
+        width,
+        breakpoint: width,
+        format: operations.format
+      }))
+    }
+
+    sizes = (sizes as Array<ImageSize>).map((size) => {
+      if (!size.format) {
+        size.format = operations.format
+      }
+      if (!size.media) {
+        size.media = size.breakpoint ? `(min-width: ${size.breakpoint}px)` : ''
+      }
+      const { url } = image(src, {
+        width: size.width,
+        height: size.height,
+        format: size.format,
+        ...operations
+      })
+      size.url = url
+      return size
+    })
+
+    return sizes
+  }
+
   image.getMeta = async (source: string, modifiers: ImageModifiers, options: any = {}) => {
-    const { src, provider: sourceProvider } = processSource(source)
-    const provider = getProvider(sourceProvider || options.provider || defaultProvider)
+    const { image } = parseImage(source, { ...modifiers, width: 30 }, options)
 
-    const sImage = provider.provider.getImage(src, { ...modifiers, width: 30 }, provider.defaults)
+    const meta = { placeholder: image.url }
 
-    const meta = await { placeholder: sImage.url }
-
-    if (typeof sImage.getMeta === 'function') {
-      Object.assign(meta, await sImage.getMeta())
+    if (typeof image.getMeta === 'function') {
+      Object.assign(meta, await image.getMeta())
     } else {
-      const baseUrl = 'http://localhost:3000'
-      const absoluteUrl = sImage.url[0] === '/' ? baseUrl + sImage.url : sImage.url
+      const internalUrl = context.ssrContext ? context.ssrContext.internalUrl : ''
+      const absoluteUrl = image.url[0] === '/' ? cleanDoubleSlashes(internalUrl + image.url) : image.url
       Object.assign(meta, await getMeta(absoluteUrl, getCache(context)))
     }
 

--- a/src/runtime/nuxt-image-mixins.ts
+++ b/src/runtime/nuxt-image-mixins.ts
@@ -79,6 +79,8 @@ export default {
   async fetch () {
     await this.fetchMeta()
 
+    // Ensure images sizes are calculate in static generation process
+    // and files are store in output direcotry
     if (this.$nuxt.context.ssrContext && this.$nuxt.context.ssrContext.isGenerating) {
       // eslint-disable-next-line no-unused-expressions
       this.sizes

--- a/src/runtime/nuxt-image-mixins.ts
+++ b/src/runtime/nuxt-image-mixins.ts
@@ -78,6 +78,11 @@ export default {
   },
   async fetch () {
     await this.fetchMeta()
+
+    if (this.$nuxt.context.ssrContext && this.$nuxt.context.ssrContext.isGenerating) {
+      // eslint-disable-next-line no-unused-expressions
+      this.sizes
+    }
   },
   data () {
     return {
@@ -121,37 +126,10 @@ export default {
       }
     },
     sizes () {
-      let sizes = this.sets
-      if (typeof this.sets === 'string') {
-        sizes = this.sets
-          .split(',')
-          .map(set => set.match(/((\d+):)?(\d+)\s*(\((\w+)\))?/)) // match: 100:100 (webp)
-          .filter(match => !!match)
-          .map((match, index) => ({
-            width: match[3],
-            breakpoint: match[2] || (index > 0 && match[3]),
-            format: match[5] || this.format
-          }))
-      }
-      if ((!Array.isArray(sizes) || !sizes.length)) {
-        sizes = [{
-          width: this.width ? parseInt(this.width, 10) : undefined,
-          height: this.height ? parseInt(this.height, 10) : undefined
-        }]
-      }
-
-      sizes = sizes.map((size) => {
-        if (!size.format) {
-          size.format = this.format
-        }
-        if (!size.media) {
-          size.media = size.breakpoint ? `(min-width: ${size.breakpoint}px)` : ''
-        }
-        size.url = this.generateSizedImage(size.width, size.height, size.format)
-        return size
+      return this.$img.sizes(this.src, this.sets, {
+        format: this.format,
+        ...this.computedOperations
       })
-
-      return sizes
     }
   },
   watch: {
@@ -206,7 +184,7 @@ export default {
           format,
           ...this.computedOperations
         })
-        return encodeURI(image)
+        return encodeURI(image.url)
       } catch (e) {
         this.onError(e)
         return ''

--- a/templates/plugin.js
+++ b/templates/plugin.js
@@ -7,6 +7,7 @@ import { createImage } from '~image/image'
 
 const intersectOptions = <%= devalue(options.intersectOptions) %>
 const defaultProvider = '<%= options.defaultProvider %>'
+const responsiveSizes = '<%= options.sizes %>'
 const presets = <%= devalue(options.presets) %>
 const providers = {}
 <% for (provider of options.providers) { %>
@@ -26,7 +27,8 @@ export default function (context, inject) {
     defaultProvider,
     providers,
     presets,
-    intersectOptions
+    intersectOptions,
+    responsiveSizes
   })
 
   inject('img', image)

--- a/test/fixture/utils/componet.ts
+++ b/test/fixture/utils/componet.ts
@@ -9,6 +9,21 @@ export function testComponent (Component, props) {
   function $img () {
     return src
   }
+  $img.sizes = () => {
+    return [{
+      width: 200,
+      url: src
+    }, {
+      width: 500,
+      media: '(min-width: 500px)',
+      url: src
+    }, {
+      width: 900,
+      media: '(min-width: 900px)',
+      format: 'webp',
+      url: src
+    }]
+  }
   $img.$observer = {
     add (_, callback) {
       observerAdded += 1

--- a/test/unit/image.test.ts
+++ b/test/unit/image.test.ts
@@ -10,7 +10,7 @@ describe('Renders simple image', () => {
   })
 })
 
-describe('Renders legacy image', () => {
+describe('Renders lazy=false', () => {
   testComponent(Component, {
     lazy: false,
     width: '200px',

--- a/test/unit/picture.test.ts
+++ b/test/unit/picture.test.ts
@@ -10,7 +10,7 @@ describe('Renders simple image', () => {
   })
 })
 
-describe('Renders legacy image', () => {
+describe('Renders lazy=false', () => {
   testComponent(Component, {
     lazy: false,
     width: '200px',

--- a/test/unit/plugin.test.ts
+++ b/test/unit/plugin.test.ts
@@ -46,12 +46,12 @@ describe('Plugin', () => {
 
   test('Generate Random Image', () => {
     const image = nuxtContext.$img('random:/test.png')
-    expect(image).toEqual('https://source.unsplash.com/random/600x400')
+    expect(image.url).toEqual('https://source.unsplash.com/random/600x400')
   })
 
   test('Generate Circle Image with Cloudinary', () => {
     const image = nuxtContext.$img('cloudinary+circle:/test.png', {})
-    expect(image).toEqual('https://res.cloudinary.com/nuxt/image/upload/r_100/test.png')
+    expect(image.url).toEqual('https://res.cloudinary.com/nuxt/image/upload/r_100/test.png')
   })
 
   test('Deny undefined provider', () => {

--- a/types/module.d.ts
+++ b/types/module.d.ts
@@ -4,6 +4,8 @@ import { ImagePreset } from './runtime'
 export interface ModuleOptions {
   defaultProvider: string;
   presets: ImagePreset[],
+  sizes: number[],
+  internalUrl?: string
   providers: {
     local: {
       dir?: string

--- a/types/runtime.d.ts
+++ b/types/runtime.d.ts
@@ -33,6 +33,13 @@ export interface ImageModifiers {
   [key: string]: any;
 }
 
+export interface ImageSize {
+  width: number;
+  media: string;
+  breakpoint: number;
+  format: string;
+}
+
 // -- Provider --
 
 export type ProviderFactory = (options: any) => Provider


### PR DESCRIPTION
With this PR:

- Image utility has sizes operation
- Module listen to a random port for internal usage
- Image utility detects client-side rendering and fallback to the original image on static images
- Rename data property to `nuxtImageMap` in order to reduce conflict possibility with users data
- Use default sizes if the user does not provide sets