### PR TITLE
Accessibility: allow empty alt attributes 

### DIFF
--- a/src/runtime/nuxt-image-mixins.ts
+++ b/src/runtime/nuxt-image-mixins.ts
@@ -49,7 +49,7 @@ export default {
     // `<img>` attrubutes
     alt: {
       type: String,
-      default: ''
+      default: undefined
     },
     referrerpolicy: {
       type: String,
@@ -121,7 +121,7 @@ export default {
       return 0
     },
     imgAttributes () {
-      const alt = this.alt ? this.alt : this.src.split(/[?#]/).shift().split('/').pop().split('.').shift()
+      const alt = this.alt === undefined ? this.src.split(/[?#]/).shift().split('/').pop().split('.').shift() : this.alt
       return {
         alt,
         referrerpolicy: this.referrerpolicy,


### PR DESCRIPTION
For accessibility it is [often a good practice to have an image with an empty alt attribute](https://www.w3.org/WAI/tutorials/images/decision-tree/), however in the current implementation of Nuxt-image it replaces the empty alt for a generated alt. 

This commit changes the behaviour so that if an alt attribute is defined by the user it will always use that, if no alt attribute is defined it will use the generated alt just like before. I have ran the tests and everything seems to be green, if you'd like I can add a test specific for this. 