### PR TITLE
feat(nuxt-img): responsive prop

### DIFF
--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -29,7 +29,7 @@
       <NuxtImg src="https://nuxtjs.org/logos/nuxt.svg" width="400" height="400" />
 
       <h2>JPEG image inside project</h2>
-      <NuxtImg src="/images/damavand.jpg" />
+      <NuxtImg responsive src="/images/damavand.jpg" />
 
       <h2>JPEG image from remote url</h2>
       <NuxtImg src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Aconcagua2016.jpg/600px-Aconcagua2016.jpg" />

--- a/src/runtime/components/nuxt-img.vue
+++ b/src/runtime/components/nuxt-img.vue
@@ -58,14 +58,9 @@ export default {
     nAttrs () {
       const attrs: any = {}
       if (this.responsive) {
-        const sizes = this.$img.getSizes(this.src, {
-          sizes: this.sizes,
-          width: this.nWidth,
-          height: this.nHeight,
-          modifiers: this.modifiers
-        })
-        attrs.sizes = sizes.map(({ width }) => `(max-width: ${width}px) ${width}px`)
-        attrs.srcSet = sizes.map(({ width, src }) => `${src} ${width}w`)
+        const { sizes, srcSet } = this.getResponsive()
+        attrs.sizes = sizes
+        attrs.srcSet = srcSet
       }
       return attrs
     },
@@ -80,6 +75,12 @@ export default {
       }
     }
   },
+  created () {
+    if (process.server && process.static) {
+      // Force compute sources into ssrContext
+      this.getResponsive()
+    }
+  },
   mounted () {
     if (this.usePlaceholder) {
       this.observe()
@@ -89,6 +90,18 @@ export default {
     this.unobserve()
   },
   methods: {
+    getResponsive () {
+      const sizes = this.$img.getSizes(this.src, {
+        sizes: this.sizes,
+        width: this.nWidth,
+        height: this.nHeight,
+        modifiers: this.modifiers
+      })
+      return {
+        sizes: sizes.map(({ width }) => `(max-width: ${width}px) ${width}px`),
+        srcSet: sizes.map(({ width, src }) => `${src} ${width}w`)
+      }
+    },
     observe () {
       this._removeObserver = useObserver(this.$el, () => {
         this.usePlaceholder = false

--- a/src/runtime/components/nuxt-img.vue
+++ b/src/runtime/components/nuxt-img.vue
@@ -4,6 +4,7 @@
     :height="height"
     :src="nSrc"
     :alt="nAlt"
+    v-bind="nAttrs"
   >
 </template>
 
@@ -32,7 +33,8 @@ export default {
 
     // options
     preset: { type: String, required: false, default: undefined },
-    provider: { type: String, required: false, default: undefined }
+    provider: { type: String, required: false, default: undefined },
+    responsive: { type: Boolean, required: false, default: false }
   },
   data () {
     return {
@@ -52,6 +54,20 @@ export default {
         preset: this.preset,
         modifiers: this.modifiers
       }).url
+    },
+    nAttrs () {
+      const attrs: any = {}
+      if (this.responsive) {
+        const sizes = this.$img.getSizes(this.src, {
+          sizes: this.sizes,
+          width: this.nWidth,
+          height: this.nHeight,
+          modifiers: this.modifiers
+        })
+        attrs.sizes = sizes.map(({ width }) => `(max-width: ${width}px) ${width}px`)
+        attrs.srcSet = sizes.map(({ width, src }) => `${src} ${width}w`)
+      }
+      return attrs
     },
     modifiers () {
       return {

--- a/src/runtime/components/nuxt-img.vue
+++ b/src/runtime/components/nuxt-img.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script lang="ts">
-import { generateAlt, useObserver } from '~image'
+import { generateAlt, useObserver, parseSize } from '~image'
 
 const EMPTY_GIF = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
 
@@ -93,8 +93,8 @@ export default {
     getResponsive () {
       const sizes = this.$img.getSizes(this.src, {
         sizes: this.sizes,
-        width: this.nWidth,
-        height: this.nHeight,
+        width: parseSize(this.width),
+        height: parseSize(this.height),
         modifiers: this.modifiers
       })
       return {


### PR DESCRIPTION
Support `<nuxt-img responsive>` to auto generate `srcSet` sources and `sizes` based on default values in order to load smaller images in responsive breakpoints. This implementation is based on new `$img.getSizes` utility.

## Alternatives:

- Using `<nuxt-picture>`
   - It works but has overhead of wrapper div (for placeholder) and
   - Less closer to native img tag for usage
- Using `<nuxt-img :srcSet="$img.sizes">`
   - More complex code when we need native like img tag and responsive sources
   - More complex usage (= less encouraging to use)
   - Need to also compute `sizes` for breakpoints


Closes #113 