### PR TITLE
fix(image): use defu for options and fix default format

### DIFF
--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -103,7 +103,7 @@ function resolveImage (ctx: ImageCTX, input: string, options: ImageOptions): Res
     _options.modifiers.height = parseSize(_options.modifiers.height)
   }
 
-  const image = provider.getImage(input, _options, ctx)
+  const image = provider.getImage(input, JSON.parse(JSON.stringify(_options)), ctx)
 
   if (_options.modifiers?.format && !image.format) {
     image.format = _options.modifiers.format

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -96,7 +96,7 @@ function resolveImage (ctx: ImageCTX, input: string, options: ImageOptions): Res
   const { provider, defaults } = getProvider(ctx, options.provider || ctx.options.provider)
   const preset = getPreset(ctx, options.preset)
 
-  const _options: ImageOptions = defu({ modifiers: {} }, options, preset, defaults)
+  const _options: ImageOptions = defu({}, options, preset, defaults)
 
   if (_options.modifiers?.width) {
     _options.modifiers.width = parseSize(_options.modifiers.width)
@@ -105,7 +105,7 @@ function resolveImage (ctx: ImageCTX, input: string, options: ImageOptions): Res
     _options.modifiers.height = parseSize(_options.modifiers.height)
   }
 
-  const image = provider.getImage(input, _options, ctx)
+  const image = provider.getImage(input, defu({ modifiers: {} }, _options), ctx)
 
   if (_options.modifiers?.format && !image.format) {
     image.format = _options.modifiers.format

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -96,7 +96,7 @@ function resolveImage (ctx: ImageCTX, input: string, options: ImageOptions): Res
   const { provider, defaults } = getProvider(ctx, options.provider || ctx.options.provider)
   const preset = getPreset(ctx, options.preset)
 
-  const _options: ImageOptions = defu({}, options, preset, defaults)
+  const _options: ImageOptions = defu(options, preset, defaults)
 
   if (_options.modifiers?.width) {
     _options.modifiers.width = parseSize(_options.modifiers.width)

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -97,6 +97,9 @@ function resolveImage (ctx: ImageCTX, input: string, options: ImageOptions): Res
   const preset = getPreset(ctx, options.preset)
 
   const _options: ImageOptions = defu(options, preset, defaults)
+  _options.modifiers = { ..._options.modifiers }
+
+  const expectedFormat = _options.modifiers?.format
 
   if (_options.modifiers?.width) {
     _options.modifiers.width = parseSize(_options.modifiers.width)
@@ -105,11 +108,9 @@ function resolveImage (ctx: ImageCTX, input: string, options: ImageOptions): Res
     _options.modifiers.height = parseSize(_options.modifiers.height)
   }
 
-  const image = provider.getImage(input, defu({ modifiers: {} }, _options), ctx)
+  const image = provider.getImage(input, _options, ctx)
 
-  if (_options.modifiers?.format && !image.format) {
-    image.format = _options.modifiers.format
-  }
+  image.format = image.format || expectedFormat || ''
 
   return image
 }

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -98,8 +98,7 @@ function resolveImage (ctx: ImageCTX, input: string, options: ImageOptions): Res
 
   const _options: ImageOptions = defu(options, preset, defaults)
   _options.modifiers = { ..._options.modifiers }
-
-  const expectedFormat = _options.modifiers?.format
+  const expectedFormat = _options.modifiers.format
 
   if (_options.modifiers?.width) {
     _options.modifiers.width = parseSize(_options.modifiers.width)

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -1,4 +1,5 @@
 import { allowList } from 'allowlist'
+import defu from 'defu'
 import { hasProtocol, joinURL } from 'ufo'
 import type { ImageOptions, CreateImageOptions, ResolvedImage, MapToStatic, ImageCTX } from '../types/image'
 import { imageMeta } from './utils/meta'
@@ -95,7 +96,8 @@ function resolveImage (ctx: ImageCTX, input: string, options: ImageOptions): Res
   const { provider, defaults } = getProvider(ctx, options.provider || ctx.options.provider)
   const preset = getPreset(ctx, options.preset)
 
-  const _options = { ...defaults, ...preset, ...options }
+  const _options: ImageOptions = defu({ modifiers: {} }, options, preset, defaults)
+
   if (_options.modifiers?.width) {
     _options.modifiers.width = parseSize(_options.modifiers.width)
   }
@@ -103,7 +105,7 @@ function resolveImage (ctx: ImageCTX, input: string, options: ImageOptions): Res
     _options.modifiers.height = parseSize(_options.modifiers.height)
   }
 
-  const image = provider.getImage(input, JSON.parse(JSON.stringify(_options)), ctx)
+  const image = provider.getImage(input, _options, ctx)
 
   if (_options.modifiers?.format && !image.format) {
     image.format = _options.modifiers.format

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -81,7 +81,7 @@ export function generateAlt (src: string = '') {
   return src.split(/[?#]/).shift().split('/').pop().split('.').shift()
 }
 
-export function parseSize (input = '') {
+export function parseSize (input: string | number = '') {
   if (typeof input === 'number') {
     return input
   }


### PR DESCRIPTION
- Recursively apply default options
- Copy modifiers reference to ensure provider cannot have side-effects
- Preserve target format to apply as default after getting image object from provider

--- 

When you run `npx nuxt generate playground  --force-build`, only images in the original format are generated because the `format` field is removed from the `options` (src/runtime/image.ts#106) object.

This PR fixes it

*Before*:
```
✔ Generated static image playground/dist/_nuxt/image/71c8ed.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/361279.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/9fa6ff.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/904ad9.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/1b223b.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/049f76.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/bec44f.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/078043.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/8ab122.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/f833c8.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/a64002.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/1b7a64.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/552e88.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/4762de.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/900e5a.jpg                                           @nuxt/image 10:25:44
✔ Generated static image playground/dist/_nuxt/image/37b3ce.jpg                                           @nuxt/image 10:25:45
✔ Generated static image playground/dist/_nuxt/image/358c84.jpg 
```

*After*:
```
✔ Generated static image playground/dist/_nuxt/image/a64002.jpeg                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/1b7a64.jpeg                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/552e88.jpeg                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/904ad9.jpeg                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/4762de.jpeg                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/1b223b.jpeg                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/049f76.jpeg                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/8ab122.jpeg                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/078043.webp                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/361279.webp                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/900e5a.webp                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/358c84.webp                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/37b3ce.webp                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/bec44f.webp                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/f833c8.webp                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/71c8ed.webp                                          @nuxt/image 10:29:14
✔ Generated static image playground/dist/_nuxt/image/9fa6ff.jpg                                           @nuxt/image 10:29:14
```