### PR TITLE
fix(observer): add `mediaQueryList` listener fallback for safari/older browsers

### DIFF
--- a/src/runtime/utils/observer.ts
+++ b/src/runtime/utils/observer.ts
@@ -67,9 +67,17 @@ function onPrint (fn) {
     return
   }
   const mediaQueryList = window.matchMedia('print')
-  mediaQueryList.addEventListener('change', (query) => {
+
+  const handleQuery = (query) => {
     if (query.matches) {
       fn()
     }
-  })
+  }
+
+  if (typeof mediaQueryList.addEventListener === 'function') {
+    mediaQueryList.addEventListener('change', handleQuery)
+  } else {
+    // Safari/Older Browser Fallback
+    mediaQueryList.addListener(handleQuery)
+  }
 }


### PR DESCRIPTION
Not sure if this is already in the process of being done, but a fallback is needed for the print listener on Safari <=13 (not sure on 14) as `MediaQueryList` still only supports `addListener` :)