### PR TITLE
Added nuxt-download-link component to generate and crawl image/PDF download links

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -71,7 +71,7 @@ async function imageModule (moduleOptions: ModuleOptions) {
   })
 
   nuxt.options.build.loaders = defu({
-    vue: { transformAssetUrls: { 'nuxt-img': 'src', 'nuxt-picture': 'src' } }
+    vue: { transformAssetUrls: { 'nuxt-img': 'src', 'nuxt-picture': 'src', 'nuxt-download-link': 'src' } }
   }, nuxt.options.build.loaders || {})
 
   nuxt.hook('generate:before', () => {

--- a/src/runtime/components/nuxt-download-link.vue
+++ b/src/runtime/components/nuxt-download-link.vue
@@ -1,0 +1,19 @@
+<template>
+  <a :key="nSrc" :href="nSrc">
+    <slot>{{ nSrc }}</slot>
+  </a>
+</template>
+
+<script lang="ts">
+import { imageMixin } from './image.mixin'
+
+export default {
+  name: 'NuxtDownloadLink',
+  mixins: [imageMixin],
+  computed: {
+    nSrc (): string {
+      return this.$img(this.src, this.nModifiers, this.nOptions)
+    }
+  }
+}
+</script>

--- a/src/runtime/plugin.js
+++ b/src/runtime/plugin.js
@@ -1,7 +1,8 @@
 import Vue from 'vue'
-import { createImage} from '~image'
+import { createImage } from '~image'
 import NuxtImg from '~image/components/nuxt-img.vue'
 import NuxtPicture from '~image/components/nuxt-picture.vue'
+import NuxtDownloadLink from '~image/components/nuxt-download-link.vue'
 
 <%=options.providers.map(p => `import * as ${p.importName} from '${p.runtime}'`).join('\n')%>
 
@@ -14,8 +15,10 @@ imageOptions.providers = {
 
 Vue.component(NuxtImg.name, NuxtImg)
 Vue.component(NuxtPicture.name, NuxtPicture)
+Vue.component(NuxtDownloadLink.name, NuxtDownloadLink)
 Vue.component('NImg', NuxtImg)
 Vue.component('NPicture', NuxtPicture)
+Vue.component('NDownloadLink', NuxtDownloadLink)
 
 export default function (nuxtContext, inject) {
   const $img = createImage(imageOptions, nuxtContext)

--- a/test/fixture/utils/download-link.ts
+++ b/test/fixture/utils/download-link.ts
@@ -1,0 +1,38 @@
+require('jsdom-global')()
+const { mount } = require('@vue/test-utils')
+
+export function testComponent (Component, props) {
+  let src = '/image.pdf'
+  function $img () {
+    return src
+  }
+  let wrapper
+  test('Mount', () => {
+    // render the component
+    wrapper = mount({
+      inject: ['$img'],
+      ...Component
+    }, {
+      propsData: {
+        ...props,
+        src
+      },
+      provide: {
+        $img
+      }
+    })
+  })
+  test('Set src', () => {
+    const domSrc = wrapper.element.getAttribute('href')
+    expect(domSrc).toEqual(src)
+  })
+  test('Change src', (done) => {
+    src = '/image.jpeg'
+    wrapper.setProps({ src })
+    process.nextTick(() => {
+      const domSrcBefore = wrapper.find('.nuxt-download-link').element.getAttribute('href')
+      expect(domSrcBefore).toEqual(src)
+      done()
+    })
+  })
+}

--- a/test/unit/download-link.test.ts
+++ b/test/unit/download-link.test.ts
@@ -1,0 +1,6 @@
+import { NuxtDownloadLink } from '../../src/runtime'
+import { testComponent } from '../fixture/utils/download-link'
+
+describe('Renders simple download link', () => {
+  testComponent(NuxtDownloadLink, {})
+})


### PR DESCRIPTION
When generating static website with content and image coming from a temporary API, we need to crawl and store images/PDF files in `_nuxt` folder in the same way *nuxt/image* crawl and store image files locally at `nuxt:generate` stage.

This PR adds a new `nuxt-download-link` component to build a `<a download>` element following the same logic as `<img>` and `<picture>`