### PR TITLE
Expose nuxtImage:updateImageMap event globally

### DIFF
--- a/src/runtime/utils/static-map.ts
+++ b/src/runtime/utils/static-map.ts
@@ -18,7 +18,11 @@ export function useStaticImageMap (nuxtContext?) {
 
   // Make sure manifest is initialized
   if ((window as any).onNuxtReady) {
-    (window as any).onNuxtReady(updateImageMap)
+    (window as any).onNuxtReady(function () {
+      updateImageMap()
+
+      window.$nuxt.$on('nuxtImage:updateImageMap', updateImageMap)
+    })
   }
 
   return staticImageMap


### PR DESCRIPTION
- **Target**: static 
- **Current behaviour**: `staticImageMap` is updated only `afterEach` router changes.

Expose `nuxtImage:updateImageMap` event globally to be able to force *nuxt/image* to append `_pagePayload?.data?.[0]?._img` from any other generated payload without any Route change or on `beforeRouteUpdate`.


```typescript
beforeRouteUpdate(to: Route, from: Route, next: Function) {
    if (this.$store.state.isAFancyEmbeddedPage) {
        /* new data, new components requiring some nuxt-img or nuxt-picture */
        this.pageData = this.$store.state.fancyEmbeddedPageData
        // Need to emit an event to force NuxtImage to append new pagePayload._img
        // to current page staticImageMap
        this.$nuxt.$emit('nuxtImage:updateImageMap')
    } else {
        next()
    }
}
```