### PR TITLE
feat: vercel image provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist/
 coverage
 sw.*
 .vscode
+.vercel_build_output

--- a/docs/content/en/4.providers/vercel.md
+++ b/docs/content/en/4.providers/vercel.md
@@ -1,0 +1,11 @@
+---
+menuTitle: Vercel
+title: Vercel
+description: 'Optimize images at Vercel's Edge Network'
+category: Providers
+---
+
+When deploying your nuxt applications to [Vercel])(https://vercel.com/) platform,
+image module can use Vercel's [Edge Network](https://vercel.com/docs/edge-network/overview) to optimize images on demand.
+
+Default provider will be auto detected upon deployment. You should keep `provier` option to be `auto` for vercel support.

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -39,6 +39,9 @@ export default <NuxtConfig> {
     imagekit: {
       baseURL: 'https://ik.imagekit.io/demo'
     },
+    vercel: {
+      baseURL: 'https://image-component.nextjs.gallery/_next/image'
+    },
     providers: {
       custom: {
         provider: '~/providers/custom',

--- a/playground/pages/index.vue
+++ b/playground/pages/index.vue
@@ -170,6 +170,14 @@
           src="https://a.storyblok.com/f/39898/1000x600/d962430746/demo-image-human.jpeg"
         />
       </div>
+
+      <h2>Vercel</h2>
+      <NuxtImg
+        width="750"
+        quality="75"
+        provider="vercel"
+        src="mountains.jpg"
+      />
     </div>
   </div>
 </template>

--- a/src/runtime/providers/vercel.ts
+++ b/src/runtime/providers/vercel.ts
@@ -1,0 +1,14 @@
+import { ProviderGetImage } from 'src'
+import { stringifyQuery } from 'ufo'
+
+// https://vercel.com/docs/more/adding-your-framework#images
+
+export const getImage: ProviderGetImage = (src, { modifiers, baseURL = '/_vercel/image' } = {}) => {
+  return {
+    url: baseURL + '?' + stringifyQuery({
+      url: src,
+      w: String(modifiers.width),
+      q: String(modifiers.quality || '100')
+    })
+  }
+}

--- a/src/types/module.d.ts
+++ b/src/types/module.d.ts
@@ -1,10 +1,15 @@
 import type { IPXOptions } from 'ipx'
 import type { ImageOptions, CreateImageOptions } from './image'
 
+// eslint-disable-next-line no-use-before-define
+export type ProviderSetup = (providerOptions: ImageModuleProvider, moduleOptions: ModuleOptions, nuxt)
+  => void | Promise<void>
+
 export interface InputProvider<T=any> {
   name?: string
   provider?: string
   options?: T
+  setup?: ProviderSetup
 }
 
 export interface ImageProviders {
@@ -29,4 +34,14 @@ export interface ModuleOptions extends ImageProviders {
   internalUrl: string
   intersectOptions: CreateImageOptions['intersectOptions']
   providers: { [name: string]: InputProvider | any } & ImageProviders
+}
+
+export interface ImageModuleProvider {
+  name: string
+  importName: string
+  options: any
+  provider: string
+  runtime: string
+  runtimeOptions: any
+  setup: ProviderSetup
 }


### PR DESCRIPTION
Support vercel provider (https://vercel.com/docs/more/adding-your-framework#images)

Core changes:
- Provider auto detection based on env (default is `auto`)
- Provider `setup` option to generate `.vercel_build_output/config/images.json`