### PR TITLE
Feat: Add srcset property to nuxt-img and nuxt-picture

### DIFF
--- a/docs/content/en/2.components/1.nuxt-img.md
+++ b/docs/content/en/2.components/1.nuxt-img.md
@@ -49,7 +49,7 @@ Specify width/height of the image.
 
 ### `sizes`
 
-Specify responsive reiszes.
+Specify responsive resizes.
 
 **Example:**
 
@@ -58,6 +58,38 @@ Specify responsive reiszes.
     src="/logos/nuxt.png"
     sizes="sm:100vw md:50vw lg:400px"
   />
+```
+
+### `srcset`
+Specify specific srcset sizes.
+
+**Example:**
+```html
+  <nuxt-img
+    src="/logos/nuxt.png"
+    srcset="150 300 450"
+  />
+
+  <!-- Generates -->
+  <img src="/logos/nuxt.png"
+       srcset="/logos/nuxt.png?w=150 150w, /logos/nuxt.png?w=300 300w, /logos/nuxt.png?w=450 450w">
+```
+
+By using `srcset` alongside the `sizes` prop you have better control over the resized images produced allowing for improved
+support for high density pixel displays and art direction.
+
+**Example with `sizes`:**
+```html
+  <nuxt-img
+    src="/logos/nuxt/png"
+    sizes="sm:100vw lg:50vw xl:800"
+    srcset="640 800 1600"
+  />
+
+  <!-- Generates -->
+  <img src="/logos/nuxt.png?w=800"
+       sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 800px"
+       srcset="/logos/nuxt.png?w=640 640w, /logos/nuxt.png?w=800 800w, /logos/nuxt.png?w=1600 1600w">
 ```
 
 ### `provider`

--- a/docs/content/en/2.components/1.nuxt-img.md
+++ b/docs/content/en/2.components/1.nuxt-img.md
@@ -61,7 +61,8 @@ Specify responsive resizes.
 ```
 
 ### `srcset`
-Specify specific srcset sizes.
+Specify specific srcset sizes.  
+Accepts a string that contains width in pixels (100 200) and/or a pixel density descriptor (x1 x2).
 
 **Example:**
 ```html
@@ -90,6 +91,22 @@ support for high density pixel displays and art direction.
   <img src="/logos/nuxt.png?w=800"
        sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 800px"
        srcset="/logos/nuxt.png?w=640 640w, /logos/nuxt.png?w=800 800w, /logos/nuxt.png?w=1600 1600w">
+```
+Instead of providing a long srcset string for hdpi devices you can provide pixel density descriptors. These will modify
+the widths the `sizes` prop would generate on its own to add the additional pixel density images.
+
+**Example with `sizes` and `srcset` descriptors:**
+```html
+  <nuxt-img
+    src="/logos/nuxt/png"
+    sizes="sm:100vw xl:800"
+    srcset="x1 x2"
+  />
+
+  <!-- Generates -->
+  <img src="/logos/nuxt.png?w=800"
+       sizes="(max-width: 640px) 100vw, 800px"
+       srcset="/logos/nuxt.png?w=640 640w, /logos/nuxt.png?w=800 800w, /logos/nuxt.png?w=1280 1280w, /logos/nuxt.png?w=1600 1600w">
 ```
 
 ### `provider`

--- a/src/runtime/components/image.mixin.ts
+++ b/src/runtime/components/image.mixin.ts
@@ -16,7 +16,7 @@ export const imageMixin = {
     provider: { type: String, default: undefined },
 
     sizes: { type: [Object, String], default: undefined },
-    srcset: { type: [Array, String], default: undefined },
+    srcset: { type: String, default: undefined },
 
     // <img> attributes
     width: { type: [String, Number], default: undefined },

--- a/src/runtime/components/image.mixin.ts
+++ b/src/runtime/components/image.mixin.ts
@@ -16,6 +16,7 @@ export const imageMixin = {
     provider: { type: String, default: undefined },
 
     sizes: { type: [Object, String], default: undefined },
+    srcset: { type: [Array, String], default: undefined },
 
     // <img> attributes
     width: { type: [String, Number], default: undefined },

--- a/src/runtime/components/nuxt-img.vue
+++ b/src/runtime/components/nuxt-img.vue
@@ -18,10 +18,13 @@ export default {
   computed: {
     nAttrs () {
       const attrs: any = this.nImgAttrs
-      if (this.sizes) {
+      if (this.sizes || this.srcset) {
         const { sizes, srcset } = this.nSizes
-        attrs.sizes = sizes
-        attrs.srcset = srcset
+        attrs.sizes = sizes || null
+        attrs.srcset = srcset || null
+      } else {
+        attrs.sizes = null
+        attrs.srcset = null
       }
       return attrs
     },
@@ -38,6 +41,7 @@ export default {
       return this.$img.getSizes(this.src, {
         ...this.nOptions,
         sizes: this.sizes,
+        srcset: this.srcset,
         modifiers: {
           ...this.nModifiers,
           width: parseSize(this.width),
@@ -48,7 +52,7 @@ export default {
   },
   created () {
     if (process.server && process.static) {
-      if (this.sizes) {
+      if (this.sizes || this.srcset) {
         // Force compute sources into ssrContext
         // eslint-disable-next-line no-unused-expressions
         this.nSizes

--- a/src/runtime/components/nuxt-picture.vue
+++ b/src/runtime/components/nuxt-picture.vue
@@ -65,6 +65,7 @@ export default {
         const { srcset, sizes, src } = this.$img.getSizes(this.src, {
           ...this.nOptions,
           sizes: this.sizes || this.$img.options.screens,
+          srcset: this.srcset,
           modifiers: {
             ...this.nModifiers,
             format
@@ -80,12 +81,6 @@ export default {
       })
 
       return sources
-    },
-    srcset () {
-      if (this.nFormat === 'svg') {
-        return
-      }
-      return this.sources.map(source => `${source.srcset} ${source.width}`)
     }
   },
   created () {

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -194,17 +194,27 @@ function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions) {
   // string => array
   if (typeof opts.srcset === 'string') {
     for (const entry of opts.srcset.split(/[ ,]+/).filter(e => e)) {
-      const size = parseInt(entry)
-      if (isNaN(size)) {
-        continue
+      if (/^[x]\d+/.test(entry)) {
+        const dpiSize = parseInt(entry.replace(/^x/, ''))
+        if (isNaN(dpiSize)) {
+          continue
+        }
+        srcset.push(...sizeVarients.map(s => s.width * dpiSize))
+      } else {
+        const size = parseInt(entry)
+        if (isNaN(size)) {
+          continue
+        }
+        srcset.push(size)
       }
-      srcset.push(size)
     }
   } else if (opts.srcset) {
     srcset.push(...opts.srcset.filter(e => !isNaN(parseInt(e))))
   }
 
-  srcset.forEach((width) => {
+  const uniqueSrcset = Array.from(new Set(srcset))
+
+  uniqueSrcset.forEach((width) => {
     const height = ratio ? Math.round(width * ratio) : parseSize(opts.modifiers.height)
     srcVarients.push({
       width,

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -191,7 +191,7 @@ function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions) {
     defaultVar.media = ''
   }
 
-  // string => array
+  // Only use srcset if it is a string
   if (typeof opts.srcset === 'string') {
     for (const entry of opts.srcset.split(/[ ,]+/).filter(e => e)) {
       if (/^[x]\d+/.test(entry)) {
@@ -208,8 +208,6 @@ function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions) {
         srcset.push(size)
       }
     }
-  } else if (opts.srcset) {
-    srcset.push(...opts.srcset.filter(e => !isNaN(parseInt(e))))
   }
 
   const uniqueSrcset = Array.from(new Set(srcset))

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -196,7 +196,7 @@ function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions) {
     for (const entry of opts.srcset.split(/[ ,]+/).filter(e => e)) {
       if (/^[x]\d+/.test(entry)) {
         const dpiSize = parseInt(entry.replace(/^x/, ''))
-        if (isNaN(dpiSize)) {
+        if (isNaN(dpiSize) || !opts.sizes) {
           continue
         }
         srcset.push(...sizeVarients.map(s => s.width * dpiSize))

--- a/src/types/image.d.ts
+++ b/src/types/image.d.ts
@@ -55,7 +55,7 @@ export interface $Img {
   (source: string, modifiers?: ImageOptions['modifiers'], options?: ImageOptions): ResolvedImage['url']
   options: CreateImageOptions
   getImage: (source: string, options?: ImageOptions) => ResolvedImage
-  getSizes: (source: string, options?: ImageOptions, sizes?: string[]) => { srcset: string, sizes: string }
+  getSizes: (source: string, options?: ImageOptions, sizes?: string[], srcset?: string[]) => { srcset: string, sizes: string }
   getMeta: (source: string, options?: ImageOptions) => Promise<ImageInfo>
   [preset: string]: $Img['options'] | $Img['getImage'] | $Img['getSizes'] | $Img['getMeta'] | $Img /* preset */
 }


### PR DESCRIPTION
As suggested in #216 the current implementation has poor support for handling different device pixel densities. This adds the _srcset_ prop as suggested by ArtCraft so you can control which image sizes are created. It supports a string of widths in pixels to overwrite the images generated by the _sizes_ prop or pixel density descriptors to adjust which images the _sizes_ prop generates.