### PR TITLE
fix: ensure static image map is available on first load

### DIFF
--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -40,8 +40,9 @@ export function createImage (globalOptions: CreateImageOptions, nuxtContext: any
 
       if (process.server) {
         const { ssrContext } = ctx.nuxtContext
+        const ssrState = ssrContext.nuxt
         const ssrData = ssrContext.nuxt.data[0]
-        const staticImages = ssrData._img = ssrData._img || {}
+        const staticImages = ssrState._img = ssrData._img = ssrData._img || {}
         const mapToStatic: MapToStatic = ssrContext.image?.mapToStatic
         if (typeof mapToStatic === 'function') {
           const mappedURL = mapToStatic(image)

--- a/src/runtime/utils/static-map.ts
+++ b/src/runtime/utils/static-map.ts
@@ -4,7 +4,12 @@ const staticImageMap = {}
 
 function updateImageMap () {
   if (typeof window.$nuxt !== 'undefined') {
+    // Client-side navigation
     const pageImages = (window.$nuxt as any)._pagePayload?.data?.[0]?._img || {}
+    Object.assign(staticImageMap, pageImages)
+  } else if (typeof (window as any).__NUXT__ !== 'undefined') {
+    // Initial load
+    const pageImages = (window as any).__NUXT__?._img || {}
     Object.assign(staticImageMap, pageImages)
   }
 }


### PR DESCRIPTION
* Worth also considering whether to use `fetch` (object syntax, but would require Nuxt 2.15+) vs `data` (?)

closes #234 

Likely also addresses https://github.com/nuxt/image/issues/167#issuecomment-826439905, https://github.com/nuxt/image/issues/215#issuecomment-826449532