### PR TITLE
fix(vercel): fix vercel auto-detection and provide local vercel mode

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -71,17 +71,22 @@ export function resolveProvider (nuxt: any, key: string, input: InputProvider): 
   }
 }
 
+const providerFlags = {
+  vercel: [process.env.VERCEL, process.env.NUXT_ENV_VERCEL_ENV, process.env.NOW_BUILDER].some(Boolean)
+}
+
 export function detectProvider (userInput?: string) {
   if (process.env.NUXT_IMAGE_PROVIDER) {
     return process.env.NUXT_IMAGE_PROVIDER
   }
 
   if (userInput && userInput !== 'auto') {
+    for (const [provider, enabled] of Object.entries(providerFlags)) {
+      if (userInput === provider && !enabled) {
+        return 'static'
+      }
+    }
     return userInput
-  }
-
-  if (process.env.VERCEL || process.env.NUXT_ENV_VERCEL_ENV) {
-    return 'vercel'
   }
 
   return 'static'

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -71,22 +71,17 @@ export function resolveProvider (nuxt: any, key: string, input: InputProvider): 
   }
 }
 
-const providerFlags = {
-  vercel: [process.env.VERCEL, process.env.NUXT_ENV_VERCEL_ENV, process.env.NOW_BUILDER].some(Boolean)
-}
-
 export function detectProvider (userInput?: string) {
   if (process.env.NUXT_IMAGE_PROVIDER) {
     return process.env.NUXT_IMAGE_PROVIDER
   }
 
   if (userInput && userInput !== 'auto') {
-    for (const [provider, enabled] of Object.entries(providerFlags)) {
-      if (userInput === provider && !enabled) {
-        return 'static'
-      }
-    }
     return userInput
+  }
+
+  if (process.env.VERCEL || process.env.VERCEL_ENV || process.env.NOW_BUILDER) {
+    return 'vercel'
   }
 
   return 'static'

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -80,7 +80,7 @@ export function detectProvider (userInput?: string) {
     return userInput
   }
 
-  if (process.env.VERCEL) {
+  if (process.env.VERCEL || process.env.NUXT_ENV_VERCEL_ENV) {
     return 'vercel'
   }
 

--- a/src/runtime/providers/vercel.ts
+++ b/src/runtime/providers/vercel.ts
@@ -3,7 +3,18 @@ import { stringifyQuery } from 'ufo'
 
 // https://vercel.com/docs/more/adding-your-framework#images
 
-export const getImage: ProviderGetImage = (src, { modifiers, baseURL = '/_vercel/image' } = {}) => {
+export const getImage: ProviderGetImage = (src, { modifiers, baseURL = '/_vercel/image' } = {}, ctx) => {
+  if (process.env.NODE_ENV === 'development') {
+    if (!modifiers?.width) {
+      console.warn(`A defined width must be provided to use the \`vercel\` provider. Warning originated from \`${src}\`.`)
+      return { url: '/_vercel/width-required' }
+    }
+    if (!Object.values(ctx.options.screens || {}).includes(Number(modifiers.width))) {
+      console.warn(`The width being used (\`${modifiers.width}\`) should be added to \`image.screens\`. Warning originated from \`${src}\`.`)
+      return { url: '/_vercel/invalid-width' }
+    }
+    return { url: src }
+  }
   return {
     url: baseURL + '?' + stringifyQuery({
       url: src,

--- a/src/runtime/providers/vercel.ts
+++ b/src/runtime/providers/vercel.ts
@@ -4,21 +4,32 @@ import { stringifyQuery } from 'ufo'
 // https://vercel.com/docs/more/adding-your-framework#images
 
 export const getImage: ProviderGetImage = (src, { modifiers, baseURL = '/_vercel/image' } = {}, ctx) => {
+  const validWidths = Object.values(ctx.options.screens || {}).sort()
+  const largestWidth = validWidths[validWidths.length - 1]
+  let width = Number(modifiers?.width || 0)
+
+  if (!width) {
+    width = largestWidth
+    if (process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line
+      console.warn(`A defined width should be provided to use the \`vercel\` provider. Defaulting to \`${largestWidth}\`. Warning originated from \`${src}\`.`)
+    }
+  } else if (!validWidths.includes(width)) {
+    width = validWidths.find(validWidth => validWidth > width) || largestWidth
+    if (process.env.NODE_ENV === 'development') {
+      // eslint-disable-next-line
+      console.warn(`The width being used (\`${modifiers?.width}\`) should be added to \`image.screens\`. Defaulting to \`${width}\`. Warning originated from \`${src}\`.`)
+    }
+  }
+
   if (process.env.NODE_ENV === 'development') {
-    if (!modifiers?.width) {
-      console.warn(`A defined width must be provided to use the \`vercel\` provider. Warning originated from \`${src}\`.`)
-      return { url: '/_vercel/width-required' }
-    }
-    if (!Object.values(ctx.options.screens || {}).includes(Number(modifiers.width))) {
-      console.warn(`The width being used (\`${modifiers.width}\`) should be added to \`image.screens\`. Warning originated from \`${src}\`.`)
-      return { url: '/_vercel/invalid-width' }
-    }
     return { url: src }
   }
+
   return {
     url: baseURL + '?' + stringifyQuery({
       url: src,
-      w: modifiers?.width ? String(modifiers.width) : undefined,
+      w: String(width),
       q: String(modifiers?.quality || '100')
     })
   }


### PR DESCRIPTION
This fixes vercel auto-detection (note the issue was only with older deployments that didn't have system environment variables exposed to the build). 

In addition, if `vercel` provider is manually selected, in development `@nuxt/image` will provide warnings if un-configured widths are used (or if no width is set manually) to prevent issues in deployment. As `@nuxt/image` is transpiled, this will be tree-shaken out in build.