### PR TITLE
docs: document `$img.getSizes`

### DIFF
--- a/docs/content/en/3.api/2.$img.md
+++ b/docs/content/en/3.api/2.$img.md
@@ -28,7 +28,7 @@ export default {
 }
 ```
 
-### `getSizes`
+### `$img.getSizes`
 
 ```js
 $img.getSizes(src, { sizes, modifiers });

--- a/docs/content/en/3.api/2.$img.md
+++ b/docs/content/en/3.api/2.$img.md
@@ -13,24 +13,6 @@ We can use `$img` utility in context to generate image URLs for any purpose not 
 $img(src, modifiers, options)
 ```
 
-```js
-$img.getSizes(src, { sizes, modifiers });
-```
-
-Parameters:
-
-- `src`: (string) Source to original image id
-- `sizes`: (string) List of responsive image sizes ({breakpoint}:{size}{unit})
-- `modifiers`: (object) Modifiers passed to provider for resizing and optimizing
-  - `width`: resize to the specified width (in pixels)
-  - `height`: resize to specified height (in pixels)
-  - `quality`: Change image quality (0 to 100)
-  - `format`: Change the image format
-  - (any other custom provider modifier)
-- `options`: (object)
-  - `provider`: (string) Provider name other than default (see [providers](https://image.nuxtjs.org/api/options#providers))
-  - `preset`: Use a [preset](/api/options#presets)
-
 **Example:** Generate image URL for `backgroundImage` style.
 
 ```js
@@ -45,6 +27,28 @@ export default {
   }
 }
 ```
+
+### `getSizes`
+
+```js
+$img.getSizes(src, { sizes, modifiers });
+```
+
+**Note:** API might change. Use with caution.
+
+Parameters:
+
+- `src`: (string) Source to original image id
+- `sizes`: (string) List of responsive image sizes ({breakpoint}:{size}{unit})
+- `modifiers`: (object) Modifiers passed to provider for resizing and optimizing
+  - `width`: resize to the specified width (in pixels)
+  - `height`: resize to specified height (in pixels)
+  - `quality`: Change image quality (0 to 100)
+  - `format`: Change the image format
+  - (any other custom provider modifier)
+- `options`: (object)
+  - `provider`: (string) Provider name other than default (see [providers](https://image.nuxtjs.org/api/options#providers))
+  - `preset`: Use a [preset](/api/options#presets)
 
 **Example:** Responsive srcset with Vuetify `v-img`
 

--- a/docs/content/en/3.api/2.$img.md
+++ b/docs/content/en/3.api/2.$img.md
@@ -11,20 +11,25 @@ We can use `$img` utility in context to generate image URLs for any purpose not 
 
 ```js
 $img(src, modifiers, options)
-````
+```
+
+```js
+$img.getSizes(src, { sizes, modifiers });
+```
 
 Parameters:
 
- - `src` (string): Source to original image id
- - `modifiers`: (object) Modifiers passed to provider for resizing and optimizing
-    - `width`: resize to the specified width (in pixels)
-    - `height`: resize to specified height (in pixels)
-    - `quality`: Change image quality (0 to 100)
-    - `format`: Change the image format
-    - (any other custom provider modifier)
- - `options`: (object)
-    - `provider`: (string) Provider name other than default (see [providers](https://image.nuxtjs.org/api/options#providers))
-    - `preset`: Use a [preset](/api/options#presets)
+- `src`: (string) Source to original image id
+- `sizes`: (string) List of responsive image sizes ({breakpoint}:{size}{unit})
+- `modifiers`: (object) Modifiers passed to provider for resizing and optimizing
+  - `width`: resize to the specified width (in pixels)
+  - `height`: resize to specified height (in pixels)
+  - `quality`: Change image quality (0 to 100)
+  - `format`: Change the image format
+  - (any other custom provider modifier)
+- `options`: (object)
+  - `provider`: (string) Provider name other than default (see [providers](https://image.nuxtjs.org/api/options#providers))
+  - `preset`: Use a [preset](/api/options#presets)
 
 **Example:** Generate image URL for `backgroundImage` style.
 
@@ -39,4 +44,41 @@ export default {
     }
   }
 }
+```
+
+**Example:** Responsive srcset with Vuetify `v-img`
+
+```html
+<template>
+<v-img
+  :lazy-src="$img(src, { width: 10, quality: 70 })"
+  :src="$img(src, { height, quality: 70 })"
+  :srcset="_srcset.srcset"
+  :height="height"
+  :sizes="_srcset.size"
+></v-img>
+</template>
+<script>
+export default {
+  props: {
+    height: { type: [Number, String], default: 500 },
+    src: {
+      type: String,
+      default: '/img/header-bg.jpg',
+    },
+  },
+  computed: {
+    _srcset() {
+      return this.$img.getSizes(this.src, {
+        sizes: 'xs:100vw sm:100vw md:100vw lg:100vw xl:100vw',
+        modifiers: {
+          format: 'webp',
+          quality: 70,
+          height: 500,
+        },
+      });
+    },
+  },
+};
+</script>
 ```


### PR DESCRIPTION
How to use the  [getSizes function](https://github.com/nuxt/image/blob/main/src/runtime/image.ts#L134-L192) and how to get a list of responsive image urls.

resolves #192