### PR TITLE
refactor: move `ipx` to runtime servermiddleware

### DIFF
--- a/docs/content/en/4.providers/ipx.md
+++ b/docs/content/en/4.providers/ipx.md
@@ -22,3 +22,53 @@ that are stored locally within your repo.
 ```
 
 This will load the image in as `/static/logo.png` and apply the IPX optimizations if applicable.
+
+
+### Using `ipx` in production
+
+#### Add `ipx` dependency
+
+You'll need to ensure that `ipx` is in your production dependencies.
+
+<d-code-group>
+  <d-code-block label="Yarn" active>
+
+```bash
+yarn add ipx
+```
+
+  </d-code-block>
+  <d-code-block label="NPM">
+
+```bash
+npm install ipx
+```
+
+  </d-code-block>
+</d-code-group>
+
+#### Add `serverMiddleware` handler
+
+You will also need to add `@nuxt/image` to your _modules_ (instead of buildModules) or add the following code to your `nuxt.config`:
+
+```js [nuxt.config.js]
+import path from 'path'
+import { createIPX, createIPXMiddleware } from 'ipx'
+
+const ipx = createIPX({
+  dir: path.join(__dirname, 'static'),
+  // https://image.nuxtjs.org/api/options#domains
+  domains: [],
+  // Any options you need to pass to sharp
+  sharp: {}
+})
+
+export default {
+  serverMiddleware: [
+    {
+      path: '/_ipx',
+      handler: createIPXMiddleware(ipx)
+    }
+  ]
+}
+```

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -1,7 +1,0 @@
-import type { IPXOptions } from 'ipx'
-
-export function createIPXMiddleware (ipxOptions: IPXOptions) {
-  const { createIPX, createIPXMiddleware } = require('ipx') as typeof import('ipx')
-  const ipx = createIPX(ipxOptions)
-  return createIPXMiddleware(ipx)
-}

--- a/src/runtime/ipx.ts
+++ b/src/runtime/ipx.ts
@@ -1,0 +1,5 @@
+import { createIPX, createIPXMiddleware } from 'ipx'
+
+const ipx = createIPX('__IPX_OPTIONS__')
+
+export default createIPXMiddleware(ipx)


### PR DESCRIPTION
This PR splits out the changes from https://github.com/nuxt/image/pull/257 (without the automatic `nuxtrc` injection, which is pending for now).

* add instructions for runtime ipx
* improve dx with warning
* don't inject ipx if user provides their own ipx mw
