### PR TITLE
docs: fix typo in code snippets

### DIFF
--- a/docs/content/en/4.providers/prismic.md
+++ b/docs/content/en/4.providers/prismic.md
@@ -7,9 +7,7 @@ category: Providers
 
 Integration between [Prismic](https://prismic.io/docs) and the image module.
 
-No specific configuration is required for Prismic support. You just need to specify `provider: 'prismic'` in your configuration to make it the default, or pass it directly when you need it, for example:
-```html
-<nuxt-img provider="prismic" src="..." />
+No specific configuration is required for Prismic support. You just need to specify `provider: 'prismic'` in your configuration to make it the default:
 
 ```js{}[nuxt.config.js]
 export default {
@@ -19,8 +17,14 @@ export default {
 }
 ```
 
-<alert type="info">
+You can also pass it directly to your component when you need it, for example:
+
+```html[*.vue]
+<nuxt-img provider="prismic" src="..." />
+```
+
+<d-alert type="info">
 
 Prismic allows content writer to manipulate images through its UI (cropping, rezising, etc.). To preserve that behavior this provider does not strip query parameters coming from Prismic. Instead it only overrides them when needed, keeping developers in control.
 
-</alert>
+</d-alert>


### PR DESCRIPTION
Following #269, there was a typo in the code snippet formatting from @danielroe (https://github.com/nuxt/image/pull/269#discussion_r633386151, https://github.com/nuxt/image/pull/269/commits/21aff062deac40d63cc755ac97aa1fc438636a13), literally made the commit at the exact same time @pi0 merged haha 🙏

Let me know if anything, cheers!