### PR TITLE
docs: add typescript setup notes

### DIFF
--- a/docs/content/en/2.setup.md
+++ b/docs/content/en/2.setup.md
@@ -52,3 +52,19 @@ export default {
 ```
 
 See [module options](/api/options).
+
+
+## TypeScript
+
+Add the types to your "types" array in `tsconfig.json` after the `@nuxt/types` (Nuxt 2.9.0+) or `@nuxt/vue-app` entry.
+
+```json [tsconfig.json]
+{
+  "compilerOptions": {
+    "types": [
+      "@nuxt/types",
+      "@nuxt/image"
+    ]
+  }
+}
+```


### PR DESCRIPTION
Without this, references to `$img` on the context will throw an error