### PR TITLE
fix: allow full usage of `$img` in plugins

### DIFF
--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -38,9 +38,8 @@ export function createImage (globalOptions: CreateImageOptions, nuxtContext: any
       if (process.server) {
         const { ssrContext } = ctx.nuxtContext
         if (ssrContext) {
-          const ssrState = ssrContext.nuxt || { data: [] }
-          const ssrData = ssrState.data[0] || {}
-          const staticImages = ssrState._img = ssrData._img = ssrData._img || {}
+          const ssrState = ssrContext.nuxt || {}
+          const staticImages = ssrState._img = ssrState._img || {}
           const mapToStatic: MapToStatic = ssrContext.image?.mapToStatic
           if (typeof mapToStatic === 'function') {
             const mappedURL = mapToStatic(image)

--- a/src/runtime/plugin.js
+++ b/src/runtime/plugin.js
@@ -19,5 +19,13 @@ Vue.component('NPicture', NuxtPicture)
 
 export default function (nuxtContext, inject) {
   const $img = createImage(imageOptions, nuxtContext)
+
+  if (process.static && process.server) {
+    nuxtContext.beforeNuxtRender(({ nuxtState }) => {
+      const ssrData = nuxtState.data[0] || {}
+      ssrData._img = nuxtState._img || {}
+    })
+  }
+  
   inject('img', $img)
 }


### PR DESCRIPTION
This PR should allow image maps generated via programmatic usage of `$img` in plugins to be accessed dynamically within the page. (Without this PR, this would work on hard-reload but not on client-side navigation as it wouldn't be included in payload.)

context: https://github.com/nuxt/image/issues/258