### PR TITLE
docs: fix typo

### DIFF
--- a/docs/pages/en/4.providers/ipx.md
+++ b/docs/pages/en/4.providers/ipx.md
@@ -33,7 +33,7 @@ If you have an advanced use case, you may instead create a custom server middlew
   ```
 
   ::::
-  ::::code-block{label="mpm"}
+  ::::code-block{label="npm"}
 
   ```bash
   npm install ipx


### PR DESCRIPTION
Fixes a code block label typo. `mpm` -> `npm`