### PR TITLE
feat: add support for netlify provider

### DIFF
--- a/docs/pages/en/4.providers/netlify.md
+++ b/docs/pages/en/4.providers/netlify.md
@@ -1,0 +1,31 @@
+---
+title: Netlify Provider
+description: Optimize images with Netlify's dynamic image transformation service.
+navigation:
+  title: Netlify
+---
+
+Netlify offers dynamic image transformation for all JPEG, PNG, and GIF files you have set to be tracked with [Netlify Large Media](https://docs.netlify.com/large-media/overview/).
+
+Set [`provider`](https://image.nuxtjs.org/api/options#provider) option to `auto` to activate it in production when deploying to Netlify:
+
+```ts [nuxt.config]
+export default {
+  image: {
+    provider: 'auto'
+  }
+}
+```
+
+:::alert{type="warning"}
+Make sure you have followed the steps to enable [Netlify Large Media](https://docs.netlify.com/large-media/overview/).
+:::
+
+## Modifiers
+
+In addition to `height` and `width`, the Netlify provider supports the following modifiers:
+
+### `fit`
+
+* **Default**: `contain`
+* **Valid options**: `contain` (equivalent to `nf_resize=fit`) and `fill` (equivalent to `nf_resize=smartcrop`)

--- a/docs/pages/en/4.providers/netlify.md
+++ b/docs/pages/en/4.providers/netlify.md
@@ -7,18 +7,8 @@ navigation:
 
 Netlify offers dynamic image transformation for all JPEG, PNG, and GIF files you have set to be tracked with [Netlify Large Media](https://docs.netlify.com/large-media/overview/).
 
-Set [`provider`](https://image.nuxtjs.org/api/options#provider) option to `auto` to activate it in production when deploying to Netlify:
-
-```ts [nuxt.config]
-export default {
-  image: {
-    provider: 'auto'
-  }
-}
-```
-
 :::alert{type="warning"}
-Make sure you have followed the steps to enable [Netlify Large Media](https://docs.netlify.com/large-media/overview/).
+Before setting `provider: 'netlify'`, make sure you have followed the steps to enable [Netlify Large Media](https://docs.netlify.com/large-media/overview/).
 :::
 
 ## Modifiers

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -40,6 +40,9 @@ export default <NuxtConfig> {
     imagekit: {
       baseURL: 'https://ik.imagekit.io/demo'
     },
+    netlify: {
+      baseURL: 'https://netlify-photo-gallery.netlify.app'
+    },
     prismic: {},
     sanity: {
       projectId: 'j1o4tmjp'

--- a/playground/providers.ts
+++ b/playground/providers.ts
@@ -67,6 +67,23 @@ export const providers: Provider[] = [
       { src: '/plant.jpeg' }
     ]
   },
+  // Netlify
+  {
+    name: 'netlify',
+    samples: [
+      {
+        src: '/images/apple.jpg',
+        width: 101,
+        fit: 'contain'
+      },
+      {
+        src: '/images/apple.jpg',
+        width: 200,
+        height: 200,
+        fit: 'fill'
+      }
+    ]
+  },
   // Prismic
   {
     name: 'prismic',

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -89,10 +89,6 @@ export function detectProvider (userInput?: string, isStatic: boolean = false) {
     return userInput
   }
 
-  if (process.env.NETLIFY) {
-    return 'netlify'
-  }
-
   if (process.env.VERCEL || process.env.VERCEL_ENV || process.env.NOW_BUILDER) {
     return 'vercel'
   }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -11,6 +11,7 @@ const BuiltInProviders = [
   'imagekit',
   'imgix',
   'ipx',
+  'netlify',
   'prismic',
   'sanity',
   'static',
@@ -86,6 +87,10 @@ export function detectProvider (userInput?: string, isStatic: boolean = false) {
 
   if (userInput && userInput !== 'auto') {
     return userInput
+  }
+
+  if (process.env.NETLIFY) {
+    return 'netlify'
   }
 
   if (process.env.VERCEL || process.env.VERCEL_ENV || process.env.NOW_BUILDER) {

--- a/src/runtime/providers/netlify.ts
+++ b/src/runtime/providers/netlify.ts
@@ -1,6 +1,5 @@
 import { joinURL } from 'ufo'
 import type { ProviderGetImage } from 'src'
-import { ImageModifiers } from 'src/types'
 import { createOperationsGenerator } from '~image'
 
 export const operationsGenerator = createOperationsGenerator({

--- a/src/runtime/providers/netlify.ts
+++ b/src/runtime/providers/netlify.ts
@@ -32,9 +32,9 @@ export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL = '/' 
     // fit is required for resizing images
     modifiers.fit = 'contain'
   }
-  if (hasTransformation && !(modifiers.height && modifiers.width)) {
+  if (hasTransformation && modifiers.fit !== 'contain' && !(modifiers.height && modifiers.width)) {
     // smartcrop is only supported with both height and width
-    if (isDev && modifiers.fit !== 'contain') {
+    if (isDev) {
       // eslint-disable-next-line
       console.warn(`Defaulting to fit=contain as smart cropping is only supported when providing both height and width. Warning originated from \`${src}\`.`)
     }

--- a/src/runtime/providers/netlify.ts
+++ b/src/runtime/providers/netlify.ts
@@ -18,15 +18,33 @@ export const operationsGenerator = createOperationsGenerator({
   formatter: (key, value) => `${key}=${value}`
 })
 
+const isDev = process.env.NODE_ENV === 'development'
+
 // https://docs.netlify.com/large-media/transform-images/
 
 export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL = '/' } = {}) => {
   if (modifiers.height || modifiers.width) {
-    modifiers.fit = modifiers.fit || 'contain'
+    if (!(modifiers.height && modifiers.width)) {
+      // smartcrop is only supported with both height and width
+      modifiers.fit = 'contain'
+      if (isDev) {
+        // eslint-disable-next-line
+        console.warn(`Reverting to fit=contain as smart cropping is only supported by providing both height and width. Warning originated from \`${src}\`.`)
+      }
+    } else {
+      modifiers.fit = modifiers.fit || 'contain'
+    }
   }
   if (modifiers.format) {
     // Not currently supported
     delete modifiers.format
+    if (isDev) {
+      // eslint-disable-next-line
+      console.warn(`Providing format is not currently supported by the Netlify provider. Warning originated from \`${src}\`.`)
+    }
+  }
+  if (isDev) {
+    return { url: src }
   }
   const operations = operationsGenerator(modifiers)
   return {

--- a/src/runtime/providers/netlify.ts
+++ b/src/runtime/providers/netlify.ts
@@ -1,0 +1,35 @@
+import { joinURL } from 'ufo'
+import type { ProviderGetImage } from 'src'
+import { createOperationsGenerator } from '~image'
+
+export const operationsGenerator = createOperationsGenerator({
+  keyMap: {
+    height: 'h',
+    fit: 'nf_resize',
+    width: 'w'
+  },
+  valueMap: {
+    fit: {
+      fill: 'smartcrop',
+      contain: 'fit'
+    }
+  },
+  joinWith: '&',
+  formatter: (key, value) => `${key}=${value}`
+})
+
+// https://docs.netlify.com/large-media/transform-images/
+
+export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL = '/' } = {}) => {
+  if (modifiers.height || modifiers.width) {
+    modifiers.fit = modifiers.fit || 'contain'
+  }
+  if (modifiers.format) {
+    // Not currently supported
+    delete modifiers.format
+  }
+  const operations = operationsGenerator(modifiers)
+  return {
+    url: joinURL(baseURL, src + (operations ? ('?' + operations) : ''))
+  }
+}

--- a/test/providers.ts
+++ b/test/providers.ts
@@ -7,6 +7,7 @@ export const images = [
     fastly: { url: '/test.png' },
     imgix: { url: '/test.png' },
     imagekit: { url: '/test.png' },
+    netlify: { url: '/test.png' },
     prismic: { url: '/test.png?auto=compress,format&rect=0,0,200,200&w=100&h=100' }
   },
   {
@@ -17,6 +18,7 @@ export const images = [
     fastly: { url: '/test.png?width=200' },
     imgix: { url: '/test.png?w=200' },
     imagekit: { url: '/test.png?tr=w-200' },
+    netlify: { url: '/test.png?w=200&nf_resize=fit' },
     prismic: { url: '/test.png?auto=compress,format&rect=0,0,200,200&w=200&h=100' }
   },
   {
@@ -27,6 +29,7 @@ export const images = [
     fastly: { url: '/test.png?height=200' },
     imgix: { url: '/test.png?h=200' },
     imagekit: { url: '/test.png?tr=h-200' },
+    netlify: { url: '/test.png?h=200&nf_resize=fit' },
     prismic: { url: '/test.png?auto=compress,format&rect=0,0,200,200&w=100&h=200' }
   },
   {
@@ -37,6 +40,7 @@ export const images = [
     fastly: { url: '/test.png?width=200&height=200' },
     imgix: { url: '/test.png?w=200&h=200' },
     imagekit: { url: '/test.png?tr=w-200,h-200' },
+    netlify: { url: '/test.png?w=200&h=200&nf_resize=fit' },
     prismic: { url: '/test.png?auto=compress,format&rect=0,0,200,200&w=200&h=200' }
   },
   {
@@ -47,6 +51,7 @@ export const images = [
     fastly: { url: '/test.png?width=200&height=200&fit=bounds' },
     imgix: { url: '/test.png?w=200&h=200&fit=fill' },
     imagekit: { url: '/test.png?tr=w-200,h-200,cm-pad_resize' },
+    netlify: { url: '/test.png?w=200&h=200&nf_resize=fit' },
     prismic: { url: '/test.png?auto=compress,format&rect=0,0,200,200&w=200&h=200&fit=fill' }
   },
   {
@@ -57,6 +62,7 @@ export const images = [
     fastly: { url: '/test.png?width=200&height=200&fit=bounds&format=jpeg' },
     imgix: { url: '/test.png?w=200&h=200&fit=fill&fm=jpeg' },
     imagekit: { url: '/test.png?tr=w-200,h-200,cm-pad_resize,f-jpeg' },
+    netlify: { url: '/test.png?w=200&h=200&nf_resize=fit' },
     prismic: { url: '/test.png?auto=compress,format&rect=0,0,200,200&w=200&h=200&fit=fill&fm=jpeg' }
   }
 ] as const

--- a/test/unit/providers.test.ts
+++ b/test/unit/providers.test.ts
@@ -7,6 +7,7 @@ import * as twicpics from '~/runtime/providers/twicpics'
 import * as fastly from '~/runtime/providers/fastly'
 import * as imgix from '~/runtime/providers/imgix'
 import * as imagekit from '~/runtime/providers/imagekit'
+import * as netlify from '~/runtime/providers/netlify'
 import * as prismic from '~/runtime/providers/prismic'
 
 describe('Providers', () => {
@@ -117,6 +118,18 @@ describe('Providers', () => {
       const [src, modifiers] = image.args
       const generated = imagekit.getImage(src, { modifiers, ...providerOptions }, {} as any)
       expect(generated).toMatchObject(image.imagekit)
+    }
+  })
+
+  test('netlify', () => {
+    const providerOptions = {
+      baseURL: ''
+    }
+
+    for (const image of images) {
+      const [src, modifiers] = image.args
+      const generated = netlify.getImage(src, { modifiers, ...providerOptions }, {} as any)
+      expect(generated).toMatchObject(image.netlify)
     }
   })
 

--- a/test/unit/providers.test.ts
+++ b/test/unit/providers.test.ts
@@ -128,7 +128,7 @@ describe('Providers', () => {
 
     for (const image of images) {
       const [src, modifiers] = image.args
-      const generated = netlify.getImage(src, { modifiers, ...providerOptions }, {} as any)
+      const generated = netlify.getImage(src, { modifiers: { ...modifiers }, ...providerOptions }, {} as any)
       expect(generated).toMatchObject(image.netlify)
     }
   })


### PR DESCRIPTION
This adds support for the Netlify image transformation service.

Note that if you want to use this, you will need to enable [Netlify Large Media](https://docs.netlify.com/large-media/overview/) on Netlify.

More information: https://docs.netlify.com/large-media/transform-images/