### PR TITLE
fix: ensure payload includes up-to-date _img

### DIFF
--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -40,6 +40,10 @@ export function createImage (globalOptions: CreateImageOptions, nuxtContext: any
         if (ssrContext) {
           const ssrState = ssrContext.nuxt || {}
           const staticImages = ssrState._img = ssrState._img || {}
+          const ssrData = ssrState.data?.[0]
+          if (ssrData) {
+            ssrData._img = staticImages
+          }
           const mapToStatic: MapToStatic = ssrContext.image?.mapToStatic
           if (typeof mapToStatic === 'function') {
             const mappedURL = mapToStatic(image)


### PR DESCRIPTION
* context: https://github.com/nuxt/image/pull/284

I'm not sure why `beforeNuxtRender` isn't properly setting the page data but this does fix the issue

closes #297