### PR TITLE
docs: add imagekit documentation

### DIFF
--- a/docs/pages/en/4.providers/imagekit.md
+++ b/docs/pages/en/4.providers/imagekit.md
@@ -1,0 +1,20 @@
+---
+title: ImageKit Provider
+description: "Nuxt Image has first class integration with ImageKit"
+navigation:
+  title: ImageKit
+---
+
+Integration between [ImageKit](https://docs.imagekit.io/) and the image module.
+
+To use this provider you just need to specify the base url of your service in ImageKit (don't forget to add your [ImageKit ID](https://docs.imagekit.io/integration/url-endpoints#default-url-endpoint)).
+
+```js{}[nuxt.config.js]
+export default {
+  image: {
+    imagekit: {
+      baseURL: 'https://ik.imagekit.io/your_imagekit_id'
+    }
+  }
+}
+```


### PR DESCRIPTION
Closes #271.

Added basic documentation for ImageKit, based on Imgix.
Tested this on a new Nuxt.js project and worked just fine.