### PR TITLE
docs: clarify src origin

### DIFF
--- a/docs/pages/en/2.components/1.nuxt-img.md
+++ b/docs/pages/en/2.components/1.nuxt-img.md
@@ -33,6 +33,8 @@ For example, the `nuxt-icon.png` referred to in the previous example should be p
 
 In other words, image stored in the `assets` directory are not compatible with Nuxt Image because those images are managed by webpack.
 
+For more information, you can learn more about the [static directory here](https://nuxtjs.org/docs/2.x/directory-structure/static).
+
 ## Props
 
 ### `src`

--- a/docs/pages/en/2.components/1.nuxt-img.md
+++ b/docs/pages/en/2.components/1.nuxt-img.md
@@ -11,6 +11,8 @@ description: Discover how to use and configure the nuxt-img component.
 - Generates responsive sizes when providing `sizes` option
 - Supports native lazy loading as well as other `<img>` attributes
 
+## Usage
+
 `nuxt-img` outputs a native `img` tag directly (without any wrapper around it). Use it like you would use the `<img>` tag:
 
 ```html
@@ -22,6 +24,14 @@ Will result in:
 ```html
 <img src="/nuxt-icon.png" />
 ```
+
+### File Location
+
+Images should be stored in the `static` directory.
+
+For example, the `nuxt-icon.png` referred to in the previous example should be placed in `static` folder under the path `/static/nuxt-icon.png`.
+
+In other words, image stored in the `assets` directory are not compatible with Nuxt Image because those images are managed by webpack.
 
 ## Props
 


### PR DESCRIPTION
Since developers may be used to managing their images in the `assets` folder, this provides clarity on where to store images and why for developers who may not be as familiar with the build system.