### PR TITLE
fix(static): url encoded name included in generated ext

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -20,9 +20,10 @@ export function setupStaticGeneration (nuxt: any, options: ModuleOptions) {
     renderContext.image.mapToStatic = <MapToStatic> function ({ url, format }: ResolvedImage) {
       if (!staticImages[url]) {
         const { pathname } = parseURL(url)
+        const [ext] = (extname(pathname) || '').split('%3F')
         const params: any = {
           name: trimExt(basename(pathname)),
-          ext: (format && `.${format}`) || extname(pathname) || '.png',
+          ext: (format && `.${format}`) || ext || '.png',
           hash: hash(url),
           // TODO: pass from runtimeConfig to mapStatic as param
           publicPath: withoutTrailingSlash(nuxt.options.build.publicPath)

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -17,13 +17,12 @@ export function setupStaticGeneration (nuxt: any, options: ModuleOptions) {
 
   nuxt.hook('vue-renderer:ssr:prepareContext', (renderContext: any) => {
     renderContext.image = renderContext.image || {}
-    renderContext.image.mapToStatic = <MapToStatic> function ({ url, format }: ResolvedImage) {
+    renderContext.image.mapToStatic = <MapToStatic> function ({ url, format }: ResolvedImage, input) {
       if (!staticImages[url]) {
-        const { pathname } = parseURL(url)
-        const [ext] = (extname(pathname) || '').split('%3F')
+        const { pathname } = parseURL(input)
         const params: any = {
           name: trimExt(basename(pathname)),
-          ext: (format && `.${format}`) || ext || '.png',
+          ext: (format && `.${format}`) || pathname.split('.').pop() || '.png',
           hash: hash(url),
           // TODO: pass from runtimeConfig to mapStatic as param
           publicPath: withoutTrailingSlash(nuxt.options.build.publicPath)

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -46,7 +46,7 @@ export function createImage (globalOptions: CreateImageOptions, nuxtContext: any
           }
           const mapToStatic: MapToStatic = ssrContext.image?.mapToStatic
           if (typeof mapToStatic === 'function') {
-            const mappedURL = mapToStatic(image)
+            const mappedURL = mapToStatic(image, input)
             if (mappedURL) {
               staticImages[image.url] = mappedURL
               image.url = mappedURL

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -106,4 +106,4 @@ export interface OperationGeneratorConfig {
   }
 }
 
-export type MapToStatic = (image: ResolvedImage) => string
+export type MapToStatic = (image: ResolvedImage, input: string) => string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,4 +23,5 @@ export function guessExt (input: string = '') {
   if (ext && /^[\w0-9]+$/.test(ext)) {
     return '.' + ext
   }
+  return ''
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -17,3 +17,10 @@ export function pick<O extends Record<any, any>, K extends keyof O> (obj: O, key
   }
   return newobj
 }
+
+export function guessExt (input: string = '') {
+  const ext = input.split('.').pop()?.split('?')[0]
+  if (ext && /^[\w0-9]+$/.test(ext)) {
+    return '.' + ext
+  }
+}


### PR DESCRIPTION
This fixes an issue with the static provider on remote domains including query params in the `nuxt generate` filename outputs.

### Example

Say I have `domains: ['https://images.prismic.io']` in my nuxt config and passing an src like `https://images.prismic.io/blog-system76/30e9de39-20a6-4caf-8728-0ec917942a0f_tumblr_4fef1ab602684355ef9596a0b9fdb122_810bfad7_1280.png?auto=compress,format&rect=56,0,700,700&w=800&h=800`, the generated nuxt image file path would end up looking like `dist/_nuxt/image/181d93.png%3Fauto=compress,format&rect=56,0,700,700&w=800&h=800`.

This PR changes it to output `dist/_nuxt/image/181d93.png` by stripping anything after `%3F` which is the url encoded `?`