### PR TITLE
docs(ipx): instructions for modifiers

### DIFF
--- a/docs/content/en/4.providers/ipx.md
+++ b/docs/content/en/4.providers/ipx.md
@@ -82,9 +82,10 @@ You can use [additional modifiers](https://github.com/unjs/ipx/#modifiers) suppo
 
 ### Animated Images
 
-**Note:** This feature is currently experimental. When used, `gif` format is converted to `webp`
-([check browser support](https://caniuse.com/webp)). Setting size is also not supported yet
-supported yet (check [lovell/sharp#2275](https://github.com/lovell/sharp/issues/2275) and [unjs/ipx#35](https://github.com/unjs/ipx/issues/35)).
+:::alert{type="info"}
+This feature is currently experimental. When using, `gif` format is converted to `webp`
+([check browser support](https://caniuse.com/webp)). Setting size is also not supported yet (check [lovell/sharp#2275](https://github.com/lovell/sharp/issues/2275) and [unjs/ipx#35](https://github.com/unjs/ipx/issues/35)).
+:::
 
 **Example:**
 

--- a/docs/content/en/4.providers/ipx.md
+++ b/docs/content/en/4.providers/ipx.md
@@ -7,24 +7,6 @@ navigation:
 
 Nuxt Image comes with a [preconfigured instance](/getting-started/providers#default-provider) of [ipx](https://github.com/unjs/ipx). An open source, self-hosted image optimizer based on [sharp](https://github.com/lovell/sharp).
 
-## Using `ipx` modifiers
-
-[Modifiers](https://github.com/unjs/ipx/#modifiers) supported by IPX can be used.
-
-```html
-<nuxt-img src="/image.png" :modifiers="{ grayscale: true, tint: '#00DC82' }" />
-```
-
-### Animated images
-
-**Note:** Animated support is currently experimental. When used, `gif` format is converted to `webp`
-([check browser support](https://caniuse.com/webp)). Setting size is also not supported yet
-supported ([lovell/sharp#2275](https://github.com/lovell/sharp/issues/2275)).
-
-```html
-<nuxt-img src="/image.gif" :modifiers="{ animated: true }" />
-```
-
 ## Using `ipx` in production
 
 Use IPX for self-hosting as an alternative to use service providers for production.
@@ -86,4 +68,26 @@ export default {
     '/_ipx': '~/server/middleware/ipx.js'
   }
 }
+```
+
+## Additional Modifiers
+
+You can use [additional modifiers](https://github.com/unjs/ipx/#modifiers) supported by IPX.
+
+**Example:**
+
+```html
+<nuxt-img src="/image.png" :modifiers="{ grayscale: true, tint: '#00DC82' }" />
+```
+
+### Animated Images
+
+**Note:** This feature is currently experimental. When used, `gif` format is converted to `webp`
+([check browser support](https://caniuse.com/webp)). Setting size is also not supported yet
+supported yet (check [lovell/sharp#2275](https://github.com/lovell/sharp/issues/2275) and [unjs/ipx#35](https://github.com/unjs/ipx/issues/35)).
+
+**Example:**
+
+```html
+<nuxt-img src="/image.gif" :modifiers="{ animated: true }" />
 ```

--- a/docs/content/en/4.providers/ipx.md
+++ b/docs/content/en/4.providers/ipx.md
@@ -7,6 +7,24 @@ navigation:
 
 Nuxt Image comes with a [preconfigured instance](/getting-started/providers#default-provider) of [ipx](https://github.com/unjs/ipx). An open source, self-hosted image optimizer based on [sharp](https://github.com/lovell/sharp).
 
+## Using `ipx` modifiers
+
+[Modifiers](https://github.com/unjs/ipx/#modifiers) supported by IPX can be used.
+
+```html
+<nuxt-img src="/image.png" :modifiers="{ grayscale: true, tint: '#00DC82' }" />
+```
+
+### Animated images
+
+They require an additional modifier and work by converting to webp
+([browser support](https://caniuse.com/webp)). Resize operations are not yet
+supported ([lovell/sharp#2275](https://github.com/lovell/sharp/issues/2275)).
+
+```html
+<nuxt-img src="/image.gif" :modifiers="{ animated: true }" />
+```
+
 ## Using `ipx` in production
 
 Use IPX for self-hosting as an alternative to use service providers for production.

--- a/docs/content/en/4.providers/ipx.md
+++ b/docs/content/en/4.providers/ipx.md
@@ -18,7 +18,7 @@ Nuxt Image comes with a [preconfigured instance](/getting-started/providers#defa
 ### Animated images
 
 **Note:** Animated support is currently experimental. When used, `gif` format is converted to `webp`
-([browser support](https://caniuse.com/webp)). Resize operations are not yet
+([check browser support](https://caniuse.com/webp)). Setting size is also not supported yet
 supported ([lovell/sharp#2275](https://github.com/lovell/sharp/issues/2275)).
 
 ```html

--- a/docs/content/en/4.providers/ipx.md
+++ b/docs/content/en/4.providers/ipx.md
@@ -17,7 +17,7 @@ Nuxt Image comes with a [preconfigured instance](/getting-started/providers#defa
 
 ### Animated images
 
-They require an additional modifier and work by converting to webp
+**Note:** Animated support is currently experimental. When used, `gif` format is converted to `webp`
 ([browser support](https://caniuse.com/webp)). Resize operations are not yet
 supported ([lovell/sharp#2275](https://github.com/lovell/sharp/issues/2275)).
 


### PR DESCRIPTION
Fixes #351.

Add instructions on how to use IPX modifiers and
also instructions on how to use animated images.