### PR TITLE
Add high density display support

### DIFF
--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -211,7 +211,7 @@ function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions) {
 
     for (const factor of highDensityFactors) {
       srcVariants.push({
-        width: _cWidth,
+        width: _cWidth * factor,
         src: ctx.$img!(input, { ...opts.modifiers, width: _cWidth * factor, height: _cHeight * factor }, opts)
       })
     }

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -160,8 +160,8 @@ function getPreset (ctx: ImageCTX, name?: string): ImageOptions {
 
 function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions) {
   const width = parseSize(opts.modifiers?.width)
-  const height = parseSize(opts.modifiers?.height) ?? 0
-  const hwRatio = (width) ? height / width : 0
+  const height = parseSize(opts.modifiers?.height)
+  const hwRatio = (width && height) ? height / width : 0
 
   const sizes: Record<string, string> = {}
 
@@ -212,7 +212,7 @@ function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions) {
     for (const factor of highDensityFactors) {
       srcVariants.push({
         width: _cWidth * factor,
-        src: ctx.$img!(input, { ...opts.modifiers, width: _cWidth * factor, height: _cHeight * factor }, opts)
+        src: ctx.$img!(input, { ...opts.modifiers, width: _cWidth * factor, height: _cHeight ? _cHeight * factor : undefined }, opts)
       })
     }
   }

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -218,6 +218,23 @@ function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions) {
   }
 
   sizeVariants.sort((v1, v2) => v1.screenMaxWidth - v2.screenMaxWidth)
+
+  // Remove duplicate size variants,
+  // `sizes="(max-width: 320px) 100vw, (max-width: 375px) 100vw, (max-width: 400px) 100vw, (max-width: 500px) 100vw, (max-width: 1000px) 100vw, 1000px"`
+  // which could be shorter:
+  // `sizes="(max-width: 1000px) 100vw, 1000px"`
+  // We can do this by removing duplicate values and only keeping the largest one
+  let previousSize = ''
+
+  // Loop in reverse order to allow safe deletion
+  for (let i = sizeVariants.length - 1; i >= 0; i--) {
+    const sizeVariant = sizeVariants[i]
+    if (sizeVariant.size === previousSize) {
+      sizeVariants.splice(i, 1)
+    }
+    previousSize = sizeVariant.size
+  }
+
   srcVariants.sort((v1, v2) => v1.width - v2.width)
 
   const defaultSize = sizeVariants[sizeVariants.length - 1]


### PR DESCRIPTION
For now, when you specify a size of 320 pixels, it will only generate an image with a size of 320px. But most smartphones have higher density displays, so we also need to add 640px (x2) and 960px (x3) to the srcset attribute (not in the sizes attribute). Adding those sizes to the currently available 'sizes' options, is not a possibility since that will also include it in the sizes attribute (which is not allowed, since that would generate incorrect media conditions)