### PR TITLE
Mismatch between domain and URL on Options

### DIFF
--- a/docs/content/en/3.api/1.options.md
+++ b/docs/content/en/3.api/1.options.md
@@ -46,7 +46,7 @@ To enable image optimization on an external website, specify which domains are a
 ```ts [nuxt.config.js]
 export default {
   image: {
-    domains: ['https://nuxtjs.org']
+    domains: ['nuxtjs.org']
   }
 }
 ```


### PR DESCRIPTION
Removed the protocol from domain options, since it's not an URL, but domain itself.