### PR TITLE
fix(vercel): sort valid widths before picking largest

### DIFF
--- a/src/runtime/providers/vercel.ts
+++ b/src/runtime/providers/vercel.ts
@@ -4,7 +4,7 @@ import { stringifyQuery } from 'ufo'
 // https://vercel.com/docs/more/adding-your-framework#images
 
 export const getImage: ProviderGetImage = (src, { modifiers, baseURL = '/_vercel/image' } = {}, ctx) => {
-  const validWidths = Object.values(ctx.options.screens || {}).sort()
+  const validWidths = Object.values(ctx.options.screens || {}).sort((a, b) => a - b)
   const largestWidth = validWidths[validWidths.length - 1]
   let width = Number(modifiers?.width || 0)
 


### PR DESCRIPTION
Default `.sort` method converts elements into strings and then sorts them in ascending order.

### Before

```
const validWidths = Object.values(sizes || {}).sort()
> [100, 1200, 150]
```

### After

```
const validWidths = Object.values(sizes || {}).sort((a, b) => a - b)
> [100, 150, 1200]
```