### PR TITLE
fix: imgAttr in nuxt-picture component

### DIFF
--- a/src/runtime/components/nuxt-picture.vue
+++ b/src/runtime/components/nuxt-picture.vue
@@ -7,7 +7,7 @@
       :sizes="nSources[1].sizes"
     >
     <img
-      v-bind="{...nImgAttrs, ...imgAttrs}"
+      v-bind="{...imgAttrs}"
       :src="nSources[0].src"
       :srcset="nSources[0].srcset"
       :sizes="nSources[0].sizes"


### PR DESCRIPTION
This is a small bugfix in the nuxt-picture.vue component to enable the imgAttr object to work.  

Link: #478