### PR TITLE
feat(storyblok): update to the new service

### DIFF
--- a/docs/content/en/4.providers/storyblok.md
+++ b/docs/content/en/4.providers/storyblok.md
@@ -11,7 +11,7 @@ Integration between [Storyblok](https://www.storyblok.com/docs/image-service/) a
 export default {
   image: {
     storyblok: {
-      baseURL: 'https://img2.storyblok.com'
+      baseURL: 'https://a.storyblok.com'
     }
   }
 }

--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -30,7 +30,7 @@ export default <NuxtConfig> {
       baseURL: 'https://demo.twic.pics/'
     },
     storyblok: {
-      baseURL: 'https://img2.storyblok.com/'
+      baseURL: 'https://a.storyblok.com/'
     },
     cloudinary: {
       baseURL: 'https://res.cloudinary.com/nuxt/image/upload/'

--- a/src/runtime/providers/storyblok.ts
+++ b/src/runtime/providers/storyblok.ts
@@ -34,7 +34,6 @@ export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL = stor
     _filters ? ('filters:' + _filters) : ''
   )
 
-  // TODO: check if hostname is https://a.storyblok.com ?
   const { pathname } = parseURL(src)
 
   const modifier = options ? '/m/' : ''

--- a/src/runtime/providers/storyblok.ts
+++ b/src/runtime/providers/storyblok.ts
@@ -2,7 +2,7 @@ import { withBase, joinURL, parseURL } from 'ufo'
 import type { ProviderGetImage } from 'src'
 
 // https://www.storyblok.com/docs/image-service
-const storyblockCDN = 'https://img2.storyblok.com'
+const storyblockCDN = 'https://a.storyblok.com'
 
 export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL = storyblockCDN } = {}) => {
   const {
@@ -37,7 +37,9 @@ export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL = stor
   // TODO: check if hostname is https://a.storyblok.com ?
   const { pathname } = parseURL(src)
 
-  const url = withBase(joinURL(options, pathname), baseURL)
+  const modifier = options ? '/m/' : ''
+
+  const url = withBase(joinURL(pathname, modifier, options), baseURL)
 
   return {
     url


### PR DESCRIPTION
Updates the `storyblok` provider to use their new [Image Service API](https://www.storyblok.com/docs/image-service#migrating-from-the-previous-version-of-the-service).

Linked to #474.