### PR TITLE
fix(nuxt-img, nuxt-picture): return empty object from `head` when preload is disabled

### DIFF
--- a/src/runtime/components/nuxt-img.vue
+++ b/src/runtime/components/nuxt-img.vue
@@ -34,6 +34,7 @@ export default defineComponent({
         ]
       }
     }
+    return {}
   },
   computed: {
     nAttrs (): NAttrs {

--- a/src/runtime/components/nuxt-picture.vue
+++ b/src/runtime/components/nuxt-picture.vue
@@ -46,6 +46,7 @@ export default defineComponent({
         link: [link]
       }
     }
+    return {}
   },
   computed: {
     isTransparent (): boolean {


### PR DESCRIPTION
Fixes #527 where not preloading images causes the app to throw an error.