### PR TITLE
Update Cloudflare  custom domain trigger path

### DIFF
--- a/docs/content/4.providers/cloudflare.md
+++ b/docs/content/4.providers/cloudflare.md
@@ -33,4 +33,4 @@ Default: `/`
 
 Your deployment's domain (zone).
 
-**Note:** `/cdn-cgi/image/` will be automatically appended for generating URLs.
+**Note:** `/cdn-cgi/imagedelivery/` will be automatically appended for generating URLs.

--- a/src/runtime/providers/cloudflare.ts
+++ b/src/runtime/providers/cloudflare.ts
@@ -40,8 +40,8 @@ export const getImage: ProviderGetImage = (src, {
   const mergeModifiers = { ...defaultModifiers, ...modifiers }
   const operations = operationsGenerator(mergeModifiers as any)
 
-  // https://<ZONE>/cdn-cgi/image/<OPTIONS>/<SOURCE-IMAGE>
-  const url = operations ? joinURL(baseURL, 'cdn-cgi/image', operations, src) : joinURL(baseURL, src)
+  // https://<ZONE>/cdn-cgi/imagedelivery/<OPTIONS>/<SOURCE-IMAGE>
+  const url = operations ? joinURL(baseURL, 'cdn-cgi/imagedelivery', operations, src) : joinURL(baseURL, src)
 
   return {
     url

--- a/test/providers.ts
+++ b/test/providers.ts
@@ -21,7 +21,7 @@ export const images = [
   {
     args: ['/test.png', { width: 200 }],
     ipx: { url: '/_ipx/w_200/test.png' },
-    cloudflare: { url: '/cdn-cgi/image/w=200/test.png' },
+    cloudflare: { url: '/cdn-cgi/imagedelivery/w=200/test.png' },
     cloudinary: { url: '/f_auto,q_auto,w_200/test' },
     twicpics: { url: '/test.png?twic=v1/cover=200x-' },
     fastly: { url: '/test.png?width=200' },
@@ -40,7 +40,7 @@ export const images = [
   {
     args: ['/test.png', { height: 200 }],
     ipx: { url: '/_ipx/h_200/test.png' },
-    cloudflare: { url: '/cdn-cgi/image/h=200/test.png' },
+    cloudflare: { url: '/cdn-cgi/imagedelivery/h=200/test.png' },
     cloudinary: { url: '/f_auto,q_auto,h_200/test' },
     twicpics: { url: '/test.png?twic=v1/cover=-x200' },
     fastly: { url: '/test.png?height=200' },
@@ -59,7 +59,7 @@ export const images = [
   {
     args: ['/test.png', { width: 200, height: 200 }],
     ipx: { url: '/_ipx/s_200x200/test.png' },
-    cloudflare: { url: '/cdn-cgi/image/w=200,h=200/test.png' },
+    cloudflare: { url: '/cdn-cgi/imagedelivery/w=200,h=200/test.png' },
     cloudinary: { url: '/f_auto,q_auto,w_200,h_200/test' },
     twicpics: { url: '/test.png?twic=v1/cover=200x200' },
     fastly: { url: '/test.png?width=200&height=200' },
@@ -78,7 +78,7 @@ export const images = [
   {
     args: ['/test.png', { width: 200, height: 200, fit: 'contain' }],
     ipx: { url: '/_ipx/fit_contain,s_200x200/test.png' },
-    cloudflare: { url: '/cdn-cgi/image/w=200,h=200,fit=contain/test.png' },
+    cloudflare: { url: '/cdn-cgi/imagedelivery/w=200,h=200,fit=contain/test.png' },
     cloudinary: { url: '/f_auto,q_auto,w_200,h_200,c_scale/test' },
     twicpics: { url: '/test.png?twic=v1/inside=200x200' },
     fastly: { url: '/test.png?width=200&height=200&fit=bounds' },
@@ -97,7 +97,7 @@ export const images = [
   {
     args: ['/test.png', { width: 200, height: 200, fit: 'contain', format: 'jpeg' }],
     ipx: { url: '/_ipx/fit_contain,f_jpeg,s_200x200/test.png' },
-    cloudflare: { url: '/cdn-cgi/image/w=200,h=200,fit=contain,f=jpeg/test.png' },
+    cloudflare: { url: '/cdn-cgi/imagedelivery/w=200,h=200,fit=contain,f=jpeg/test.png' },
     cloudinary: { url: '/f_jpg,q_auto,w_200,h_200,c_scale/test' },
     twicpics: { url: '/test.png?twic=v1/output=jpeg/inside=200x200' },
     fastly: { url: '/test.png?width=200&height=200&fit=bounds&format=jpeg' },


### PR DESCRIPTION
Cloudflare updated the CGI path a day ago. That's why this update is needed.

Old path:   /cgi-cdn/image
New path: /cgi-cdn/imagedelivery

Updated document link: https://developers.cloudflare.com/images/cloudflare-images/serve-images/

![image](https://user-images.githubusercontent.com/4970593/177039337-13a474de-ee68-4e6d-832f-7eb23721e00f.png)
