### PR TITLE
docs: advice `modules` instead of `buildModules`

### DIFF
--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -21,7 +21,7 @@ Add `@nuxt/image-edge` as a devDependency to your project:
   ```
 ::
 
-Add the module to `buildModules` in your `nuxt.config`:
+Add the module to `modules` in your `nuxt.config`:
 
 ```ts [nuxt.config.js]
 export default {


### PR DESCRIPTION
As of Nuxt 3, `buildModules` property is deprecated. Use `modules` instead.