### PR TITLE
Fixed broken Getting Started link in Docs (v0)

### DIFF
--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -4,7 +4,7 @@ description: Using image module in your Nuxt project is only one command away. â
 ---
 
 ::alert{type="info"}
-You are reading the `v0` documentation compatible with **Nuxt 2**. Check out the [v1.image.nuxtjs.org](https://v1.image.nuxtjs.org/getting-started/installation) for **Nuxt 3** support. ([Announcement](https://github.com/nuxt/image/discussions/548)).
+You are reading the `v0` documentation compatible with **Nuxt 2**. Check out the [v1.image.nuxtjs.org](https://v1.image.nuxtjs.org/get-started) for **Nuxt 3** support. ([Announcement](https://github.com/nuxt/image/discussions/548)).
 ::
 
 Add `@nuxt/image` devDependency to your project:


### PR DESCRIPTION
Currently v0 users are redirected to a 404 page not found page when they click on "Check out the v1.image.nuxtjs.org" link in the [Docs](https://image.nuxtjs.org/getting-started/installation).

This PR fixes the URL to be: https://v1.image.nuxtjs.org/get-started instead of https://v1.image.nuxtjs.org/getting-started/installation.