### PR TITLE
docs: fix broken link

### DIFF
--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -4,7 +4,7 @@ description: Using image module in your Nuxt project is only one command away. â
 ---
 
 ::alert{type="info"}
-You are reading the `v0` documentation compatible with **Nuxt 2**. Check out the [v1.image.nuxtjs.org](https://v1.image.nuxtjs.org/getting-started/installation) for **Nuxt 3** support. ([Announcement](https://github.com/nuxt/image/discussions/548)).
+You are reading the `v0` documentation compatible with **Nuxt 2**. Check out the [v1.image.nuxtjs.org](https://v1.image.nuxtjs.org/get-started) for **Nuxt 3** support. ([Announcement](https://github.com/nuxt/image/discussions/548)).
 ::
 
 Add `@nuxt/image` devDependency to your project:

--- a/docs/content/1.getting-started/1.installation.md
+++ b/docs/content/1.getting-started/1.installation.md
@@ -4,7 +4,7 @@ description: Using image module in your Nuxt project is only one command away. â
 ---
 
 ::alert{type="info"}
-You are reading the `v0` documentation compatible with **Nuxt 2**. Check out the [v1.image.nuxtjs.org](https://v1.image.nuxtjs.org/get-started) for **Nuxt 3** support. ([Announcement](https://github.com/nuxt/image/discussions/548)).
+You are reading the `v0` documentation compatible with **Nuxt 2**. Check out [v1.image.nuxtjs.org](https://v1.image.nuxtjs.org/get-started) for **Nuxt 3** support. ([Announcement](https://github.com/nuxt/image/discussions/548)).
 ::
 
 Add `@nuxt/image` devDependency to your project:


### PR DESCRIPTION
v1.image.nuxtjs.org does not contain a /get-started/installation route. The directions for installation are at that route.

Also, the actual route is "get-started" vs "getting-started". Not sure if someone wants to fix that. 