### PR TITLE
fix(picture): Render nuxt picture default img with passed sizes

### DIFF
--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -211,9 +211,11 @@ function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions) {
     defaultVar.media = ''
   }
 
+  const defaultSrcWithAdaptedSize = ctx.$img!(input, { ...opts.modifiers, width, height }, opts)
+
   return {
     sizes: variants.map(v => `${v.media ? v.media + ' ' : ''}${v.size}`).join(', '),
     srcset: variants.map(v => `${v.src} ${v.width}w`).join(', '),
-    src: defaultVar?.src
+    src: defaultSrcWithAdaptedSize
   }
 }


### PR DESCRIPTION
🔗 Linked issue
[resolves https://github.com/nuxt/image/issues/584](https://github.com/nuxt/image/issues/584)

❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

📚 Description
This renders the passed sizes of the picture element in the default image source. This will prevent, ensure that the default loaded image has the size of the passed parameters.

📝 Checklist
- [x] I have linked an issue or discussion.
- [ ]  I have updated the documentation accordingly.