### PR TITLE
Add support for densities

### DIFF
--- a/playground/pages/responsive.vue
+++ b/playground/pages/responsive.vue
@@ -17,12 +17,14 @@
     <nuxt-img
       src="/logos/nuxt.png"
       sizes="sm:100vw md:50vw lg:400px"
+      densities="1x"
       loading="lazy"
     />
     <br>
     <nuxt-picture
       src="/logos/nuxt.png"
       sizes="sm:100vw md:50vw lg:400px"
+      densities="1x"
       loading="lazy"
     />
   </div>

--- a/src/runtime/components/image.mixin.ts
+++ b/src/runtime/components/image.mixin.ts
@@ -21,6 +21,7 @@ export const imageMixin = defineMixin({
     provider: { type: String, default: undefined },
 
     sizes: { type: [Object, String] as unknown as () => string | Record<string, any>, default: undefined },
+    densities: { type: String, default: undefined },
     preload: { type: Boolean, default: undefined },
 
     // <img> attributes

--- a/src/runtime/components/nuxt-img.vue
+++ b/src/runtime/components/nuxt-img.vue
@@ -14,6 +14,7 @@ const defineComponent: DefineComponentWithMixin = (opts: any) => opts
 type NAttrs = typeof imageMixin['nImgAttrs'] & {
     sizes?: string
     srcset?: string
+    densities?: string
 }
 
 export default defineComponent({
@@ -54,6 +55,7 @@ export default defineComponent({
       return this.$img.getSizes(this.src, {
         ...this.nOptions,
         sizes: this.sizes,
+        densities: this.densities,
         modifiers: {
           ...this.nModifiers,
           width: parseSize(this.width),

--- a/src/runtime/components/nuxt-picture.vue
+++ b/src/runtime/components/nuxt-picture.vue
@@ -89,6 +89,7 @@ export default defineComponent({
         const { srcset, sizes, src } = this.$img.getSizes(this.src, {
           ...this.nOptions,
           sizes: this.sizes || this.$img.options.screens,
+          densities: this.densities,
           modifiers: {
             ...this.nModifiers,
             format

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -91,3 +91,10 @@ export function parseSize (input: string | number | undefined = '') {
     }
   }
 }
+
+export function parseDensities (input: string | undefined = '') {
+  if (!input.length) {
+    return undefined
+  }
+  return input.split(' ').map(size => parseInt(size.replace('x', ''), 10))
+}

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -9,6 +9,7 @@ export interface ImageModifiers {
 export interface ImageOptions {
   provider?: string,
   preset?: string,
+  densities?: string,
   modifiers?: Partial<ImageModifiers>
   [key: string]: any
 }


### PR DESCRIPTION
This PR is based on #459 and enables using a new `densities` attribute to generate larger images for displays with higher resolutions.  

Factors must be separated by spaces and followed by the `x` symbol.   

If the attribute is not specified, the default would be `1x 2x`

This would generate the following sizes : 100px, 300px, 800px:
```vue
<nuxt-img
  src="..."
  sizes="sm:100px md:300px lg:800px"
  densities="1x"
/>
```

This would generate the following sizes : 100px, 200px, 300px, 600px, 800px, 1600px:
```vue
<nuxt-img
  src="..."
  sizes="sm:100px md:300px lg:800px"
  densities="1x 2x"
/>
```