### PR TITLE
fix(nuxt-img): access `prerender.env` only in server side

### DIFF
--- a/src/runtime/components/nuxt-img.ts
+++ b/src/runtime/components/nuxt-img.ts
@@ -86,7 +86,7 @@ export default defineComponent({
       })
     }
 
-    if (typeof process !== 'undefined' && process.env && process.env.prerender) {
+    if (process.server && process.env.prerender) {
       const sources = [
         src.value,
         ...(sizes.value.srcset || '').split(',').map(s => s.split(' ')[0])

--- a/src/runtime/components/nuxt-img.ts
+++ b/src/runtime/components/nuxt-img.ts
@@ -86,7 +86,7 @@ export default defineComponent({
       })
     }
 
-    if (process.env.prerender) {
+    if (typeof process !== 'undefined' && process.env && process.env.prerender) {
       const sources = [
         src.value,
         ...(sizes.value.srcset || '').split(',').map(s => s.split(' ')[0])


### PR DESCRIPTION
resolves #660 