### PR TITLE
docs: fix typo

### DIFF
--- a/docs/content/5.configuration.md
+++ b/docs/content/5.configuration.md
@@ -156,7 +156,7 @@ You can use this option to change filename and location for the static image gen
 ```ts [nuxt.config.js]
 export default {
   image: {
-      // Generate images to `/_nuxt/image/file.png`
+      // Generate images to `/_nuxt/images/file.png`
       staticFilename: '[publicPath]/images/[name]-[hash][ext]'
   }
 }


### PR DESCRIPTION
For '[publicPath]/images/[name]-[hash][ext]' it should be:
`/_nuxt/image/file.png` -> `/_nuxt/images/file.png`