### PR TITLE
Fix IPX static generation issue when using multiple format options

### DIFF
--- a/playground/providers.ts
+++ b/playground/providers.ts
@@ -20,6 +20,7 @@ export const providers: Provider[] = [
         from: 'Jeremy Thomas',
         width: 300,
         height: 300,
+        quality: 70,
         link: 'https://unsplash.com/@jeremythomasphoto?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText'
       },
       {

--- a/src/runtime/components/nuxt-img.ts
+++ b/src/runtime/components/nuxt-img.ts
@@ -89,7 +89,7 @@ export default defineComponent({
     if (process.server && process.env.prerender) {
       const sources = [
         src.value,
-        ...(sizes.value.srcset || '').split(',').map(s => s.split(' ')[0])
+        ...(sizes.value.srcset || '').split(',').map(s => s.trim().split(' ')[0])
       ].filter(s => s && s.includes('/_ipx/'))
       appendHeader(useRequestEvent(), 'X-Nitro-Prerender', sources.join(','))
     }

--- a/src/runtime/providers/ipx.ts
+++ b/src/runtime/providers/ipx.ts
@@ -12,7 +12,7 @@ const operationsGenerator = createOperationsGenerator({
     quality: 'q',
     background: 'b'
   },
-  joinWith: ',',
+  joinWith: '_',
   formatter: (key, val) => encodeParam(key) + '_' + encodeParam(val)
 })
 


### PR DESCRIPTION
This fixes an issue with the IPX provider when multiple formatting options are applied.

Modified playground sample data as a minimal reproduction.

To test:
1. Make the change to `playground/providers.ts` shown here: https://github.com/nuxt/image/pull/673/files#diff-cdfcb4bb4c632950a1a834b483f874c9c3f5090efb60a1467e9e994403361276
2. Run `npm run dev:generate` and `npx serve playground/.output/public`
3. Observe colors image does not load on IPX page
4. Now apply the changes from this PR and run `npm run dev:generate` and `npx serve playground/.output/public`
5. Color image now loads