### PR TITLE
docs: fix cloudflare usage example

### DIFF
--- a/docs/content/5.providers/cloudflare.md
+++ b/docs/content/5.providers/cloudflare.md
@@ -13,7 +13,9 @@ To use this provider you just need to specify the base url (zone) of your servic
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
   image: {
-    baseURL: 'https://that-test.site'
+    cloudflare: {
+      baseURL: 'https://that-test.site'
+    }
   }
 })
 ```


### PR DESCRIPTION
The example in the documentation for the Cloudflare provider is missing the parent `cloudflare` object. The current example doesn't work on the latest version.