### PR TITLE
fix(prerender): Encode URLs to preserve "," in X-Nitro-Prerender Header

### DIFF
--- a/src/runtime/components/nuxt-img.ts
+++ b/src/runtime/components/nuxt-img.ts
@@ -90,7 +90,7 @@ export default defineComponent({
       const sources = [
         src.value,
         ...(sizes.value.srcset || '').split(',').map(s => s.split(' ')[0])
-      ].filter(s => s && s.includes('/_ipx/'))
+      ].filter(s => s && s.includes('/_ipx/')).map((source) => source.replace(',', '&'));
       appendHeader(useRequestEvent(), 'X-Nitro-Prerender', sources.join(','))
     }
 

--- a/src/runtime/components/nuxt-img.ts
+++ b/src/runtime/components/nuxt-img.ts
@@ -90,7 +90,7 @@ export default defineComponent({
       const sources = [
         src.value,
         ...(sizes.value.srcset || '').split(',').map(s => s.split(' ')[0])
-      ].filter(s => s && s.includes('/_ipx/')).map((source) => source.replace(',', '&'));
+      ].filter(s => s && s.includes('/_ipx/')).map(source => source.replace(',', '&'))
       appendHeader(useRequestEvent(), 'X-Nitro-Prerender', sources.join(','))
     }
 


### PR DESCRIPTION
When using IPX provider in combination with `placeholder` attribute the final URL that will get added to the `X-Nitro-Prerender` header contains a plain comma.

Due to the way nitropack currently works this will break static generation of these images due to this [LOC in nitropack](https://github.com/unjs/nitro/blob/main/src/prerender.ts?rgh-link-date=2022-07-06T15%3A08%3A53Z#L260):
```typescript
_links.push(...header.split(",").map((i) => i.trim()));
```

You can reproduce the issue yourself with the latest NPM version of `@nuxt/image-edge` (^1.0.0-27840416.dc1ed65):

```vue
<template>
<div>
     <nuxt-img src="images/logo.svg" /> 
     <nuxt-img src="images/logo.svg" placeholder />
</div>
</template>
```

When using the above vue component only one image will get statically generated when running `yarn run generate`.
The placeholder image gets lost due to the URL being `/_ipx/q_50,s_10x10/images/logo.svg` which nitropack reads as:

- /_ipx/_50
- s_10x10/images/logo.svg

This bug is (closely) related to the following issues:
- #689 
- #690
- #671 

I've also opened a companion PR on nitropack here: https://github.com/unjs/nitro/pull/799