### PR TITLE
fix(unsplash): merge query params with src

### DIFF
--- a/playground/providers.ts
+++ b/playground/providers.ts
@@ -662,6 +662,16 @@ export const providers: Provider[] = [
         format: 'auto',
         from: 'Photo by Omid Armin',
         link: 'https://unsplash.com/@omidarmin?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText'
+      },
+      {
+        src: 'https://images.unsplash.com/photo-1532236204992-f5e85c024202?crop=entropy&cs=tinysrgb&ixid=MnwxOTgwMDZ8MHwxfHNlYXJjaHwyOHx8dG9reW98ZW58MHx8fHwxNjczNzk3MDIz',
+        width: 300,
+        height: 300,
+        fit: 'cover',
+        quality: 75,
+        format: 'auto',
+        from: 'Photo by Jezael Melgoza',
+        link: 'https://unsplash.com/@jezar?utm_source=unsplash&utm_medium=referral&utm_content=creditCopyText'
       }
     ]
   },

--- a/playground/providers.ts
+++ b/playground/providers.ts
@@ -664,7 +664,7 @@ export const providers: Provider[] = [
         link: 'https://unsplash.com/@omidarmin?utm_source=unsplash&amp;utm_medium=referral&amp;utm_content=creditCopyText'
       },
       {
-        src: 'https://images.unsplash.com/photo-1532236204992-f5e85c024202?crop=entropy&cs=tinysrgb&ixid=MnwxOTgwMDZ8MHwxfHNlYXJjaHwyOHx8dG9reW98ZW58MHx8fHwxNjczNzk3MDIz',
+        src: 'https://images.unsplash.com/photo-1532236204992-f5e85c024202?crop=entropy&cs=tinysrgb&ixid=MnwxOTgwMDZ8MHwxfHNlYXJjaHwyOHx8dG9reW98ZW58MHx8fHwxNjczNzk3MDIz&w=500',
         width: 300,
         height: 300,
         fit: 'cover',

--- a/src/runtime/providers/unsplash.ts
+++ b/src/runtime/providers/unsplash.ts
@@ -1,6 +1,6 @@
 // https://unsplash.com/documentation#dynamically-resizable-images
 
-import { joinURL, withBase } from 'ufo'
+import { getQuery, withBase, withQuery } from 'ufo'
 import type { ProviderGetImage } from '../../types'
 import { operationsGenerator } from './imgix'
 
@@ -8,8 +8,8 @@ const unsplashCDN = 'https://images.unsplash.com/'
 
 export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL = unsplashCDN } = {}) => {
   const operations = operationsGenerator(modifiers)
-  const hasQueryParams = src.includes('?')
+  // withQuery requires query parameters as an object, so I parse the modifiers into an object with getQuery
   return {
-    url: withBase(joinURL(src + (operations ? ((hasQueryParams ? '&' : '?') + operations) : '')), baseURL)
+    url: withQuery(withBase(src, baseURL), getQuery('?' + operations))
   }
 }

--- a/src/runtime/providers/unsplash.ts
+++ b/src/runtime/providers/unsplash.ts
@@ -8,7 +8,8 @@ const unsplashCDN = 'https://images.unsplash.com/'
 
 export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL = unsplashCDN } = {}) => {
   const operations = operationsGenerator(modifiers)
+  const hasQueryParams = src.includes('?')
   return {
-    url: withBase(joinURL(src + (operations ? ('?' + operations) : '')), baseURL)
+    url: withBase(joinURL(src + (operations ? ((hasQueryParams ? '&' : '?') + operations) : '')), baseURL)
   }
 }


### PR DESCRIPTION
Edits done: Edited the provider for Unsplash, added a new case to the playground for Unsplash

Hi everyone, I found out that when using URLs which already contains query parameters, the provider will wrongly attach a '?'  instead of using a & before the applied operations and Unsplash would ignore the first passed operation. 

In these cases, placing a & would be the correct option.

I think another workaround would be to always place a '&' after '?' Like this: `?&`  but I don't think is elegant.

Here's an example of one generate url wrong: 
https://images.unsplash.com/photo-1532236204992-f5e85c024202?crop=entropy&cs=tinysrgb&fm=jpg&ixid=MnwxOTgwMDZ8MHwxfHNlYXJjaHwyOHx8dG9reW98ZW58MHx8fHwxNjczNzk3MDIz&ixlib=rb-4.0.3&q=80?w=300&q=80
 The wrong part: ` &q=80?w=300&q=80`

Here's how it should appear correctly generated: https://images.unsplash.com/photo-1532236204992-f5e85c024202?crop=entropy&cs=tinysrgb&fm=jpg&ixid=MnwxOTgwMDZ8MHwxfHNlYXJjaHwyOHx8dG9reW98ZW58MHx8fHwxNjczNzk3MDIz&ixlib=rb-4.0.3&q=80&w=300&q=80
 The corrected part: ` &q=80&w=300&q=80`

And this is the source url: https://images.unsplash.com/photo-1532236204992-f5e85c024202?crop=entropy&cs=tinysrgb&fm=jpg&ixid=MnwxOTgwMDZ8MHwxfHNlYXJjaHwyOHx8dG9reW98ZW58MHx8fHwxNjczNzk3MDIz&ixlib=rb-4.0.3&q=80

I tried it in the playground and it works. 
I'm open to edit it if there's a better way of doing it. 