### PR TITLE
fix(cloudinary): update mapping key for `density`

### DIFF
--- a/docs/content/5.providers/cloudinary.md
+++ b/docs/content/5.providers/cloudinary.md
@@ -259,6 +259,10 @@ Call a custom function on Cloudinary side. See [Custom Functions](https://cloudi
 
 To define the density number when converting a vector file to image format.
 
+### `aspectRatio`
+
+To crop or resize the asset to a new aspect ratio, for use with a crop/resize mode that determines how the asset is adjusted to the new dimensions.
+
 ::alert{type="info"}
 See [Cloudinary Image Transformation API](https://cloudinary.com/documentation/image_transformation_reference) for more details.
 ::

--- a/src/runtime/providers/cloudinary.ts
+++ b/src/runtime/providers/cloudinary.ts
@@ -28,7 +28,8 @@ const operationsGenerator = createOperationsGenerator({
     zoom: 'z',
     colorSpace: 'cs',
     customFunc: 'fn',
-    density: 'dpi'
+    density: 'dn',
+    aspectRatio: 'ar',
   },
   valueMap: {
     fit: {


### PR DESCRIPTION
- update mapping key for cloudinary `density` from `dpi` to `dn`. https://cloudinary.com/documentation/transformation_reference#dn_density
- add support for aspect ratio

<img width="1162" alt="image" src="https://user-images.githubusercontent.com/15758406/215429320-ecc84a20-bb8c-4202-ae15-bbba77ec4117.png">
