### PR TITLE
feat: add data-nuxt-img and data-nuxt-pic attrs

### DIFF
--- a/src/runtime/components/nuxt-img.ts
+++ b/src/runtime/components/nuxt-img.ts
@@ -37,7 +37,7 @@ export default defineComponent({
     }))
 
     const attrs = computed(() => {
-      const attrs: AttrsT = {..._base.attrs.value, 'data-nuxt-img': ''}
+      const attrs: AttrsT = { ..._base.attrs.value, 'data-nuxt-img': ''}
       if (props.sizes) {
         attrs.sizes = sizes.value.sizes
         attrs.srcset = sizes.value.srcset

--- a/src/runtime/components/nuxt-img.ts
+++ b/src/runtime/components/nuxt-img.ts
@@ -37,7 +37,7 @@ export default defineComponent({
     }))
 
     const attrs = computed(() => {
-      const attrs: AttrsT = { ..._base.attrs.value, 'data-nuxt-img': ''}
+      const attrs: AttrsT = { ..._base.attrs.value, 'data-nuxt-img': '' }
       if (props.sizes) {
         attrs.sizes = sizes.value.sizes
         attrs.srcset = sizes.value.srcset

--- a/src/runtime/components/nuxt-img.ts
+++ b/src/runtime/components/nuxt-img.ts
@@ -23,6 +23,7 @@ export default defineComponent({
     type AttrsT = typeof _base.attrs.value & {
       sizes?: string
       srcset?: string
+      'data-nuxt-img'?: string
     }
 
     const sizes = computed(() => $img.getSizes(props.src, {
@@ -36,7 +37,7 @@ export default defineComponent({
     }))
 
     const attrs = computed(() => {
-      const attrs: AttrsT = _base.attrs.value
+      const attrs: AttrsT = {..._base.attrs.value, 'data-nuxt-img': ''}
       if (props.sizes) {
         attrs.sizes = sizes.value.sizes
         attrs.srcset = sizes.value.srcset

--- a/src/runtime/components/nuxt-picture.ts
+++ b/src/runtime/components/nuxt-picture.ts
@@ -65,13 +65,13 @@ export default defineComponent({
     }
 
     // Only passdown supported <image> attributes
-    const imgAttrs: {[key: string]: string|unknown} = { ...props.imgAttrs, 'data-nuxt-pic': '' }
+    const imgAttrs: Record<string, string | unknown> = { ...props.imgAttrs, 'data-nuxt-pic': '' }
     for (const key in ctx.attrs) {
       if (key in baseImageProps && !(key in imgAttrs)) {
         imgAttrs[key] = ctx.attrs[key]
       }
     }
-    
+
     const imgEl = ref<HTMLImageElement>()
 
     // Prerender static images

--- a/src/runtime/components/nuxt-picture.ts
+++ b/src/runtime/components/nuxt-picture.ts
@@ -65,13 +65,13 @@ export default defineComponent({
     }
 
     // Only passdown supported <image> attributes
-    const imgAttrs = { ...props.imgAttrs }
+    const imgAttrs: {[key: string]: string|unknown} = { ...props.imgAttrs, 'data-nuxt-pic': '' }
     for (const key in ctx.attrs) {
       if (key in baseImageProps && !(key in imgAttrs)) {
         imgAttrs[key] = ctx.attrs[key]
       }
     }
-
+    
     const imgEl = ref<HTMLImageElement>()
 
     // Prerender static images


### PR DESCRIPTION
This commit adds data attributes to usages of nuxt/image and nuxt/picture. This will allow us to compare performance results (in aggregate) for apps that use the components against apps that use normal `<img>` or `<picture>` tags. Currently, it isn't possible because there isn't a good way to distinguish the two in HTTP Archive.

Doing such a perf comparison allows us to:
- ensure that these components actually improve performance
- catch and fix performance regressions quickly