### PR TITLE
docs: fix typo in api docs

### DIFF
--- a/docs/content/4.api/2.$img.md
+++ b/docs/content/4.api/2.$img.md
@@ -19,10 +19,8 @@ $img(src, modifiers, options)
 ```js
 const $img = useImage()
 const backgroundStyles = computed(() => {
-  return {
-    const imgUrl = $img('https://github.com/nuxt.png', { width: 100 })
-    backgroundImage: `url('${imgUrl}')`
-  }
+  const imgUrl = $img('https://github.com/nuxt.png', { width: 100 })
+  return { backgroundImage: `url('${imgUrl}')` }
 })
 ```
 


### PR DESCRIPTION
Usage chapter example updated. There was a typo in returned object.