### PR TITLE
strapi local image sharp provider

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -26,6 +26,7 @@ const BuiltInProviders = [
   'sanity',
   'twicpics',
   'strapi',
+  'strapisharp',
   'storyblok',
   'unsplash',
   'vercel',

--- a/src/runtime/providers/strapisharp.ts
+++ b/src/runtime/providers/strapisharp.ts
@@ -1,0 +1,42 @@
+import { joinURL } from 'ufo'
+import type { ProviderGetImage } from '../../types'
+import { createOperationsGenerator } from '#image'
+
+// https://strapi-community.github.io/strapi-plugin-local-image-sharp/
+
+const operationsGenerator = createOperationsGenerator({
+  keyMap: {
+    width: 'width',
+    height: 'height',
+    resize: 'resize',
+    fit: 'fit',
+    position: 'positon',
+    trim: 'trim',
+    format: 'format',
+    quality: 'quality',
+    rotate: 'rotate',
+    enlarge: 'enlarge',
+    flip: 'flip',
+    flop: 'flop',
+    sharpen: 'sharpen',
+    median: 'median',
+    gamma: 'gamma',
+    negate: 'negate',
+    normalize: 'normalize',
+    threshold: 'threshold',
+    grayscale: 'grayscale',
+    animated: 'animated'
+  },
+  joinWith: ',',
+  formatter: (key, value) => `${key}_${value}`
+})
+
+export const getImage: ProviderGetImage = (src, { modifiers, baseURL = 'http://localhost:1337/uploads' } = {}) => {
+  const operations = operationsGenerator(modifiers as any)
+
+  return {
+    url: joinURL(baseURL, operations, src)
+  }
+}
+
+export const validateDomains = true

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -57,6 +57,7 @@ export interface ImageProviders {
   twicpics?: any
   storyblok?: any,
   strapi?: any,
+  strapisharp?: any,
   imageengine?: any,
   ipx?: Partial<IPXOptions>
   static?: Partial<IPXOptions>


### PR DESCRIPTION
Hello,

I created this originally to solve https://github.com/nuxt/image/issues/641. Strapi doesn't normally provide modifiers beyond "breakpoint". Since the `sizes` prop uses `width` & `height` path/query url parameters to request appropriately sized images, it normally has no effect. However, when the [local image sharp](https://strapi-community.github.io/strapi-plugin-local-image-sharp/guide/modifiers.html#normalize) plugin is installed in Strapi, it provides many modifiers (including width & height). This provides the necessary parameters for the sizes prop to function properly while also allowing additional modifiers through the local image sharp plugin.

This could perhaps be included in the Strapi provider with the functionality being enabled through a nuxt.config.strapi boolean (`localImageSharp: boolean` or similar), but for now, I've separated it into it's own provider. I'm happy to refactor it however after some review and do a PR for the docs as well.

Look forward to hearing from you. Thanks for reading!