### PR TITLE
fix(ipx): use `node.req` and `node.res`

### DIFF
--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -49,7 +49,7 @@ export const ipxSetup: ProviderSetup = async (providerOptions, moduleOptions) =>
   nuxt.options.devServerHandlers.push({
     route: '/_ipx',
     handler: eventHandler(async (event) => {
-      await middleware(event.req, event.res)
+      await middleware(event.node.req, event.node.res)
     })
   })
 }

--- a/src/runtime/ipx.ts
+++ b/src/runtime/ipx.ts
@@ -16,7 +16,7 @@ export default lazyEventHandler(() => {
   const middleware = createIPXMiddleware(ipx)
 
   return eventHandler(async (event) => {
-    event.req.url = withLeadingSlash(event.context.params._)
-    await middleware(event.req, event.res)
+    event.node.req.url = withLeadingSlash(event.context.params._)
+    await middleware(event.node.req, event.node.res)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This swaps out deprecated property use for newer `node.res` and `node.req` objects.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
