### PR TITLE
fix(ipx): support runtime nuxt `baseURL` 

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -63,7 +63,7 @@ export default defineNuxtModule<ModuleOptions>({
     options.provider = detectProvider(options.provider)
     options[options.provider] = options[options.provider] || {}
 
-    const imageOptions: Omit<CreateImageOptions, 'providers'> = pick(options, [
+    const imageOptions: Omit<CreateImageOptions, 'providers' | 'nuxt'> = pick(options, [
       'screens',
       'presets',
       'provider',

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,10 +1,16 @@
 import { createImage } from '#image'
 // @ts-ignore
 import { imageOptions } from '#build/image-options'
-import { defineNuxtPlugin } from '#imports'
+import { defineNuxtPlugin, useRuntimeConfig } from '#imports'
 
 export default defineNuxtPlugin(() => {
-  const img = createImage(imageOptions)
+  const config = useRuntimeConfig()
+  const img = createImage({
+    ...imageOptions,
+    nuxt: {
+      baseURL: config.app.baseURL
+    }
+  })
   return {
     provide: {
       img

--- a/src/runtime/providers/ipx.ts
+++ b/src/runtime/providers/ipx.ts
@@ -16,7 +16,7 @@ const operationsGenerator = createOperationsGenerator({
   formatter: (key, val) => encodeParam(key) + '_' + encodeParam(val)
 })
 
-export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL } = {}, _ctx) => {
+export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL } = {}, ctx) => {
   if (modifiers.width && modifiers.height) {
     modifiers.resize = `${modifiers.width}x${modifiers.height}`
     delete modifiers.width
@@ -26,8 +26,7 @@ export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL } = {}
   const params = operationsGenerator(modifiers) || '_'
 
   if (!baseURL) {
-    // TODO: Support base url
-    baseURL = joinURL('/', '/_ipx')
+    baseURL = joinURL(ctx.options.nuxt.baseURL, '/_ipx')
   }
 
   return {

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -34,6 +34,9 @@ export interface CreateImageOptions {
       provider: ImageProvider
     }
   }
+  nuxt: {
+    baseURL: string
+  }
   presets: { [name: string]: ImageOptions }
   provider: string
   screens: Record<string, number>

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -7,14 +7,14 @@ export interface ImageModifiers {
 }
 
 export interface ImageOptions {
-  provider?: string,
-  preset?: string,
+  provider?: string
+  preset?: string
   modifiers?: Partial<ImageModifiers>
   [key: string]: any
 }
 
 export interface ImageSizesOptions extends ImageOptions {
-  sizes: Record<string, string|number> | string
+  sizes: Record<string, string | number> | string
 }
 
 // eslint-disable-next-line no-use-before-define
@@ -30,21 +30,21 @@ export interface ImageProvider {
 export interface CreateImageOptions {
   providers: {
     [name: string]: {
-      defaults: any,
+      defaults: any
       provider: ImageProvider
     }
   }
   presets: { [name: string]: ImageOptions }
   provider: string
-  screens: Record<string, number>,
-  alias: Record<string, string>,
+  screens: Record<string, number>
+  alias: Record<string, string>
   domains: string[]
 }
 
 export interface ImageInfo {
-  width: number,
-  height: number,
-  placeholder?: string,
+  width: number
+  height: number
+  placeholder?: string
 }
 
 export interface ResolvedImage {
@@ -72,20 +72,20 @@ export type $Img = Img & {
 }
 
 export interface ImageCTX {
-  options: CreateImageOptions,
+  options: CreateImageOptions
   $img?: $Img
 }
 
 export interface ImageSize {
-  width: number;
-  media: string;
-  breakpoint: number;
-  format: string;
-  url: string;
+  width: number
+  media: string
+  breakpoint: number
+  format: string
+  url: string
 }
 
 export interface RuntimePlaceholder extends ImageInfo {
-  url: string;
+  url: string
 }
 
 export type OperationFormatter = (key: string, value: string) => string


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/image/issues/665
https://github.com/nuxt/image/discussions/548

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds a new property `nuxt.baseURL` to global image options. Providers like IPX can take this into account when rendering their image URLs.

Some linting also took place in the types file - apologies, I couldn't resist, but I separated out the commit.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
