### PR TITLE
fix(ipx): use actual relative ipx dir

### DIFF
--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -1,4 +1,4 @@
-import { resolve } from 'pathe'
+import { relative, resolve } from 'pathe'
 import { eventHandler } from 'h3'
 import { useNuxt, createResolver } from '@nuxt/kit'
 
@@ -28,8 +28,10 @@ export const ipxSetup: ProviderSetup = async (providerOptions, moduleOptions) =>
   if (!nuxt.options.dev) {
     // TODO: Avoid adding for non-Node.js environments with a warning
     const resolver = createResolver(import.meta.url)
-    ipxOptions.dir = '' // Set at runtime
-    nuxt.options.runtimeConfig.ipx = ipxOptions
+    nuxt.hook('nitro:init', (nitro) => {
+      ipxOptions.dir = relative(nitro.options.output.serverDir, nitro.options.output.publicDir)
+      nitro.options.runtimeConfig.ipx = ipxOptions
+    })
     nuxt.options.serverHandlers.push({
       route: '/_ipx/**',
       handler: resolver.resolve('./runtime/ipx')

--- a/src/runtime/ipx.ts
+++ b/src/runtime/ipx.ts
@@ -5,11 +5,11 @@ import { eventHandler, lazyEventHandler } from 'h3'
 import { useRuntimeConfig } from '#imports'
 
 export default lazyEventHandler(() => {
+  const opts = useRuntimeConfig().ipx
   const ipxOptions = {
-    ...(useRuntimeConfig().ipx || {}),
+    ...(opts || {}),
     // TODO: Switch to storage API when ipx supports it
-    // TODO: Using relative paths for POC only
-    dir: fileURLToPath(new URL(process.env.prerender ? '../../.output/public' : '../public', import.meta.url))
+    dir: fileURLToPath(new URL(opts.dir, import.meta.url))
   }
 
   const ipx = createIPX(ipxOptions)


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/image/issues/749
resolves https://github.com/nuxt/image/issues/758

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This removes hardcoded relative paths for the public dir. In so doing it fixes a couple of bugs with netlify, but also for any other preset which didn't output to `../public` (next to a server directory).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
