### PR TITLE
fix(ipx): set prerenderer config as well

### DIFF
--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -30,7 +30,8 @@ export const ipxSetup: ProviderSetup = async (providerOptions, moduleOptions) =>
     const resolver = createResolver(import.meta.url)
     nuxt.hook('nitro:init', (nitro) => {
       ipxOptions.dir = relative(nitro.options.output.serverDir, nitro.options.output.publicDir)
-      nitro.options.runtimeConfig.ipx = ipxOptions
+      nitro.options._config.runtimeConfig = nitro.options._config.runtimeConfig || {}
+      nitro.options._config.runtimeConfig.ipx = nitro.options.runtimeConfig.ipx = ipxOptions
     })
     nuxt.options.serverHandlers.push({
       route: '/_ipx/**',

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -30,6 +30,8 @@ export const ipxSetup: ProviderSetup = async (providerOptions, moduleOptions) =>
     const resolver = createResolver(import.meta.url)
     nuxt.hook('nitro:init', (nitro) => {
       ipxOptions.dir = relative(nitro.options.output.serverDir, nitro.options.output.publicDir)
+      // TODO: Workaround for prerender support
+      // https://github.com/nuxt/image/pull/784
       nitro.options._config.runtimeConfig = nitro.options._config.runtimeConfig || {}
       nitro.options._config.runtimeConfig.ipx = nitro.options.runtimeConfig.ipx = ipxOptions
     })


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/image/issues/780

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Nitro prerenderer does not share the same runtimeConfig instance so we can set it on `_config`.

Opening the PR as hotfix but we may also want to change behaviour in nitro or provide a hook to allow us to configure the prerenderer more specifically (even just another call of `nitro:config` would be ideal).

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
