### PR TITLE
fix: use absolute path for prerenderer

### DIFF
--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -30,14 +30,13 @@ export const ipxSetup: ProviderSetup = async (providerOptions, moduleOptions) =>
     const resolver = createResolver(import.meta.url)
     nuxt.hook('nitro:init', (nitro) => {
       // Use absolute path for prerenderer
+      // TODO: Workaround for prerender support
+      // https://github.com/nuxt/image/pull/784
       nitro.options._config.runtimeConfig = nitro.options._config.runtimeConfig || {}
       nitro.options._config.runtimeConfig.ipx = { ...ipxOptions }
       // Use relative path for built app
       ipxOptions.dir = relative(nitro.options.output.serverDir, nitro.options.output.publicDir)
-      // TODO: Workaround for prerender support
-      // https://github.com/nuxt/image/pull/784
-      nitro.options._config.runtimeConfig = nitro.options._config.runtimeConfig || {}
-      nitro.options._config.runtimeConfig.ipx = nitro.options.runtimeConfig.ipx = ipxOptions
+      nitro.options.runtimeConfig.ipx = ipxOptions
     })
     nuxt.options.serverHandlers.push({
       route: '/_ipx/**',

--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -29,6 +29,10 @@ export const ipxSetup: ProviderSetup = async (providerOptions, moduleOptions) =>
     // TODO: Avoid adding for non-Node.js environments with a warning
     const resolver = createResolver(import.meta.url)
     nuxt.hook('nitro:init', (nitro) => {
+      // Use absolute path for prerenderer
+      nitro.options._config.runtimeConfig = nitro.options._config.runtimeConfig || {}
+      nitro.options._config.runtimeConfig.ipx = { ...ipxOptions }
+      // Use relative path for built app
       ipxOptions.dir = relative(nitro.options.output.serverDir, nitro.options.output.publicDir)
       // TODO: Workaround for prerender support
       // https://github.com/nuxt/image/pull/784


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/nuxt/image/issues/780#issuecomment-1489048172

### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Ugh. Apologies for the iteration on this one. I think we'll need to use an absolute path for the prerenderer, and relative for the built version.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
