### PR TITLE
fix: correctly apply provided format to `<NuxtPicture>`

### DIFF
--- a/src/runtime/components/nuxt-picture.ts
+++ b/src/runtime/components/nuxt-picture.ts
@@ -22,7 +22,7 @@ export default defineComponent({
 
     const originalFormat = computed(() => getFileExtension(props.src))
 
-    const format = computed(() => props.format || originalFormat.value === 'svg' ? 'svg' : 'webp')
+    const format = computed(() => props.format || (originalFormat.value === 'svg' ? 'svg' : 'webp'))
 
     const legacyFormat = computed(() => {
       if (props.legacyFormat) { return props.legacyFormat }


### PR DESCRIPTION
The resulting value of format.value will always be "svg" if a custom format is provided