### PR TITLE
fix: emit synthetic load/error events on initial hydration

### DIFF
--- a/src/runtime/components/nuxt-img.ts
+++ b/src/runtime/components/nuxt-img.ts
@@ -3,7 +3,7 @@ import { useImage } from '../composables'
 import { parseSize } from '../utils'
 import { prerenderStaticImages } from '../utils/prerender'
 import { baseImageProps, useBaseImage } from './_base'
-import { useHead } from '#imports'
+import { useHead, useNuxtApp } from '#imports'
 
 export const imgProps = {
   ...baseImageProps,
@@ -13,7 +13,7 @@ export const imgProps = {
 export default defineComponent({
   name: 'NuxtImg',
   props: imgProps,
-  emits: ['load'],
+  emits: ['load', 'error'],
   setup: (props, ctx) => {
     const $img = useImage()
     const _base = useBaseImage(props)
@@ -95,6 +95,8 @@ export default defineComponent({
 
     const imgEl = ref<HTMLImageElement>()
 
+    const nuxtApp = useNuxtApp()
+    const initialLoad = nuxtApp.isHydrating
     onMounted(() => {
       if (placeholder.value) {
         const img = new Image()
@@ -104,10 +106,21 @@ export default defineComponent({
           placeholderLoaded.value = true
           ctx.emit('load', event)
         }
-      } else {
-        imgEl.value!.onload = (event) => {
-          ctx.emit('load', event)
+        return
+      }
+
+      if (imgEl.value!.complete && initialLoad) {
+        if (imgEl.value?.getAttribute('data-error')) {
+          ctx.emit('error', new Event('error'))
+        } else {
+          ctx.emit('load', new Event('load'))
         }
+      }
+      imgEl.value!.onload = (event) => {
+        ctx.emit('load', event)
+      }
+      imgEl.value!.onerror = (event) => {
+        ctx.emit('error', event)
       }
     })
 
@@ -115,6 +128,7 @@ export default defineComponent({
       ref: imgEl,
       key: src.value,
       src: src.value,
+      ...process.server ? { onerror: 'this.setAttribute(\'data-error\', 1)' } : {},
       ...attrs.value,
       ...ctx.attrs
     })

--- a/src/runtime/components/nuxt-picture.ts
+++ b/src/runtime/components/nuxt-picture.ts
@@ -86,7 +86,7 @@ export default defineComponent({
     onMounted(() => {
       if (!imgEl.value) { return }
 
-      if (imgEl.value.complete && initialLoad && imgEl.value.naturalWidth !== 0) {
+      if (imgEl.value.complete && initialLoad && !imgEl.value.getAttribute('data-error')) {
         ctx.emit('load', new Event('load'))
       }
       imgEl.value.onload = (event) => {
@@ -105,6 +105,7 @@ export default defineComponent({
       h('img', {
         ref: imgEl,
         ..._base.attrs.value,
+        ...process.server ? { onerror: 'this.setAttribute(\'data-error\', 1)' } : {},
         ...imgAttrs,
         src: sources.value[0].src,
         sizes: sources.value[0].sizes,

--- a/src/runtime/components/nuxt-picture.ts
+++ b/src/runtime/components/nuxt-picture.ts
@@ -1,7 +1,7 @@
 import { h, defineComponent, ref, computed, onMounted } from 'vue'
 import { prerenderStaticImages } from '../utils/prerender'
 import { useBaseImage, baseImageProps } from './_base'
-import { useImage, useHead } from '#imports'
+import { useImage, useHead, useNuxtApp } from '#imports'
 import { getFileExtension } from '#image'
 
 export const pictureProps = {
@@ -81,7 +81,12 @@ export default defineComponent({
       }
     }
 
+    const nuxtApp = useNuxtApp()
+    const initialLoad = nuxtApp.isHydrating
     onMounted(() => {
+      if (imgEl.value!.complete && initialLoad && imgEl.value!.naturalWidth !== 0) {
+        ctx.emit('load', new Event('load'))
+      }
       imgEl.value!.onload = (event) => {
         ctx.emit('load', event)
       }

--- a/test/e2e/no-ssr.test.ts
+++ b/test/e2e/no-ssr.test.ts
@@ -39,9 +39,7 @@ describe('browser (ssr: false)', () => {
 
     expect(requests.map(r => r.replace(url('/'), '/')).filter(r => r !== providerPath && !r.match(/\.(js|css)/))).toMatchSnapshot()
   })
-})
 
-describe('browser (ssr: false) common', () => {
   it('should emit load and error events', async () => {
     const page = await createPage(url('/events'))
     const logs: string[] = []

--- a/test/e2e/ssr.test.ts
+++ b/test/e2e/ssr.test.ts
@@ -40,4 +40,18 @@ describe('browser (ssr: true)', () => {
 
     expect(requests.map(r => r.replace(url('/'), '/')).filter(r => r !== providerPath && !r.match(/\.(js|css)/))).toMatchSnapshot()
   })
+
+  it('should emit load and error events', async () => {
+    const page = await createPage()
+    const logs: string[] = []
+
+    page.on('console', (msg) => { logs.push(msg.text()) })
+
+    page.goto(url('/events'))
+
+    await page.waitForLoadState('networkidle')
+
+    expect(logs.filter(log => log === 'Image was loaded').length).toBe(4)
+    expect(logs.filter(log => log === 'Error loading image').length).toBe(1)
+  })
 })


### PR DESCRIPTION
resolves https://github.com/nuxt/image/issues/682
resolves https://github.com/nuxt/image/issues/412

This PR emits load/error events on initial hydration for better DX if the load/error event has already occurred before hydration.