### PR TITLE
fix(pkg): use esm build as `main` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "nuxt/image",
   "license": "MIT",
   "sideEffects": false,
-  "main": "./dist/module.cjs",
+  "main": "./dist/module.mjs",
   "types": "./dist/module.d.ts",
   "files": [
     "dist"


### PR DESCRIPTION
This PR should resolve https://github.com/nuxt/image/issues/379
I'm open for any kind of feedback or improvement.