### PR TITLE
fix(storyblok): don't apply resize/format/filter on vector

### DIFF
--- a/src/runtime/providers/storyblok.ts
+++ b/src/runtime/providers/storyblok.ts
@@ -16,7 +16,7 @@ export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL = stor
   } = modifiers
 
   const isSVG = src.endsWith('.svg')
-  const doResize = !isSVG && (width !=='0' || height !== '0')
+  const doResize = !isSVG && (width !== '0' || height !== '0')
 
   if (!isSVG) {
     if (format) {

--- a/src/runtime/providers/storyblok.ts
+++ b/src/runtime/providers/storyblok.ts
@@ -14,15 +14,15 @@ export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL = stor
     format,
     quality
   } = modifiers
-  
-  const isSVG = src.endsWith(".svg")
-  const doResize = !isSVG && (width !== "0" || height !== "0")
 
-  if(!isSVG) {
+  const isSVG = src.endsWith('.svg')
+  const doResize = !isSVG && (width !=='0' || height !== '0')
+
+  if (!isSVG) {
     if (format) {
       filters.format = format + ''
     }
-  
+
     if (quality) {
       filters.quality = quality + ''
     }

--- a/src/runtime/providers/storyblok.ts
+++ b/src/runtime/providers/storyblok.ts
@@ -14,15 +14,18 @@ export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL = stor
     format,
     quality
   } = modifiers
+  
+  const isSVG = src.endsWith(".svg")
+  const doResize = !isSVG && (width !== "0" || height !== "0")
 
-  const doResize = width !== '0' || height !== '0'
-
-  if (format) {
-    filters.format = format + ''
-  }
-
-  if (quality) {
-    filters.quality = quality + ''
+  if(!isSVG) {
+    if (format) {
+      filters.format = format + ''
+    }
+  
+    if (quality) {
+      filters.quality = quality + ''
+    }
   }
 
   const _filters = Object.entries(filters || {}).map(e => `${e[0]}(${e[1]})`).join(':')


### PR DESCRIPTION
Given the nature of headless CMS we sometimes don't know what image type will be passed into `nuxt-img`. This prevents any resizing, formatting and filtering on vector images. Today if any of these are applied storyblok either responds with a `40X` error or the image appears distorted.