### PR TITLE
fix: address miscellaneous bugs with new 'densities' prop

### DIFF
--- a/src/runtime/components/nuxt-img.ts
+++ b/src/runtime/components/nuxt-img.ts
@@ -39,19 +39,9 @@ export default defineComponent({
 
     const attrs = computed(() => {
       const attrs: AttrsT = { ..._base.attrs.value, 'data-nuxt-img': '' }
-      if (props.sizes && (!props.placeholder || placeholderLoaded.value)) {
+      if (!props.placeholder || placeholderLoaded.value) {
         attrs.sizes = sizes.value.sizes
         attrs.srcset = sizes.value.srcset
-      } else if (props.densities || $img.options.densities) {
-        attrs.srcset = $img.getDensitySet(props.src!, {
-          ..._base.options.value,
-          densities: props.densities,
-          modifiers: {
-            ..._base.modifiers.value,
-            width: parseSize(props.width),
-            height: parseSize(props.height)
-          }
-        })
       }
       return attrs
     })
@@ -113,7 +103,7 @@ export default defineComponent({
         const img = new Image()
         img.src = mainSrc.value
         if (props.sizes) {
-          img.sizes = sizes.value.sizes
+          img.sizes = sizes.value.sizes || ''
           img.srcset = sizes.value.srcset
         }
         img.onload = (event) => {

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -131,10 +131,8 @@ function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions): Image
   const width = parseSize(opts.modifiers?.width)
   const height = parseSize(opts.modifiers?.height)
   const sizes = parseSizes(opts.sizes)
-  const densities = opts.densities ? parseDensities(opts.densities) : ctx.options.densities // TODO: test empty string with whitespaces
+  const densities = opts.densities?.trim() ? parseDensities(opts.densities.trim()) : ctx.options.densities
   if (densities.length === 0) {
-    // TODO: add test with empty densities
-    // TODO: throw error or fallback to '1x' or to global default `ctx.options.densities`
     throw new Error('\'densities\' must not be empty, configure to \'1\' to render regular size only (DPR 1.0)')
   }
 

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -102,3 +102,21 @@ export function parseDensities (input: string | undefined = ''): number[] {
   // de-duplicate and return
   return densities.filter((value, index) => densities.indexOf(value) === index)
 }
+
+export function parseSizes (input: Record<string, string | number> | string): Record<string, string> {
+  const sizes: Record<string, string> = {}
+  // string => object
+  if (typeof input === 'string') {
+    for (const entry of input.split(/[\s,]+/).filter(e => e)) {
+      const s = entry.split(':')
+      if (s.length !== 2) {
+        sizes[s[0].trim()] = s[0].trim()
+      } else {
+        sizes[s[0].trim()] = s[1].trim()
+      }
+    }
+  } else {
+    Object.assign(sizes, input)
+  }
+  return sizes
+}

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -60,7 +60,7 @@ export interface ResolvedImage {
 
 export interface ImageSizes {
   srcset: string
-  sizes: string
+  sizes: string | undefined
   src: string
 }
 

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -107,3 +107,10 @@ export interface OperationGeneratorConfig {
 }
 
 export type MapToStatic = (image: ResolvedImage, input: string) => string
+
+export interface ImageSizesVariant {
+  size?: string
+  screenMaxWidth: number
+  _cWidth: number
+  _cHeight?: number | undefined
+}

--- a/test/unit/image.test.ts
+++ b/test/unit/image.test.ts
@@ -19,7 +19,7 @@ describe('Renders simple image', () => {
   })
 
   it('Matches snapshot', () => {
-    expect(wrapper.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1800x1800/image.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/s_500x500/image.png 500w, /_ipx/s_900x900/image.png 900w, /_ipx/s_1000x1000/image.png 1000w, /_ipx/s_1800x1800/image.png 1800w\\">"')
+    expect(wrapper.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1800x1800/image.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/s_200x200/image.png 200w, /_ipx/s_400x400/image.png 400w, /_ipx/s_500x500/image.png 500w, /_ipx/s_900x900/image.png 900w, /_ipx/s_1000x1000/image.png 1000w, /_ipx/s_1800x1800/image.png 1800w\\">"')
   })
 
   it('props.src is picked up by getImage()', () => {
@@ -38,7 +38,7 @@ describe('Renders simple image', () => {
 
   it('sizes', () => {
     const sizes = wrapper.find('img').element.getAttribute('sizes')
-    expect(sizes).toBe('(max-width: 500px) 500px, 900px')
+    expect(sizes).toBe('(max-width: 200px) 200px, (max-width: 500px) 500px, 900px')
   })
 
   it('applies densities', () => {
@@ -50,6 +50,26 @@ describe('Renders simple image', () => {
       src: 'image.png'
     })
     expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1200x1800/image.png\\" width=\\"200\\" height=\\"300\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 300px) 300px, 400px\\" srcset=\\"/_ipx/s_300x450/image.png 300w, /_ipx/s_400x600/image.png 400w, /_ipx/s_600x900/image.png 600w, /_ipx/s_800x1200/image.png 800w, /_ipx/s_900x1350/image.png 900w, /_ipx/s_1200x1800/image.png 1200w\\">"')
+  })
+
+  it('with single sizes entry', () => {
+    const img = mountImage({
+      src: '/image.png',
+      width: 300,
+      height: 400,
+      sizes: '150'
+    })
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_300x400/image.png\\" width=\\"300\\" height=\\"400\\" data-nuxt-img=\\"\\" srcset=\\"/_ipx/s_150x200/image.png 1x, /_ipx/s_300x400/image.png 2x\\">"')
+  })
+
+  it('with single sizes entry (responsive)', () => {
+    const img = mountImage({
+      src: '/image.png',
+      width: 300,
+      height: 400,
+      sizes: 'sm:150'
+    })
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_300x400/image.png\\" width=\\"300\\" height=\\"400\\" data-nuxt-img=\\"\\" srcset=\\"/_ipx/s_150x200/image.png 1x, /_ipx/s_300x400/image.png 2x\\">"')
   })
 
   it('de-duplicates sizes & srcset', () => {
@@ -69,7 +89,7 @@ describe('Renders simple image', () => {
       sizes: '200,500:500,900:900',
       src: '/汉字.png'
     })
-    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1800x1800/%E6%B1%89%E5%AD%97.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/s_500x500/%E6%B1%89%E5%AD%97.png 500w, /_ipx/s_900x900/%E6%B1%89%E5%AD%97.png 900w, /_ipx/s_1000x1000/%E6%B1%89%E5%AD%97.png 1000w, /_ipx/s_1800x1800/%E6%B1%89%E5%AD%97.png 1800w\\">"')
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1800x1800/%E6%B1%89%E5%AD%97.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/s_200x200/%E6%B1%89%E5%AD%97.png 200w, /_ipx/s_400x400/%E6%B1%89%E5%AD%97.png 400w, /_ipx/s_500x500/%E6%B1%89%E5%AD%97.png 500w, /_ipx/s_900x900/%E6%B1%89%E5%AD%97.png 900w, /_ipx/s_1000x1000/%E6%B1%89%E5%AD%97.png 1000w, /_ipx/s_1800x1800/%E6%B1%89%E5%AD%97.png 1800w\\">"')
   })
 
   it('correctly sets crop', () => {
@@ -173,14 +193,14 @@ describe('Renders placeholded image', () => {
     let sizes = wrapper.find('img').element.getAttribute('sizes')
 
     expect(sizes).toBe(null)
-    expect(placeholderImage.sizes).toBe('(max-width: 500px) 500px, 900px')
+    expect(placeholderImage.sizes).toBe('(max-width: 200px) 200px, (max-width: 500px) 500px, 900px')
 
     resolveImage()
     await nextTick()
 
     sizes = wrapper.find('img').element.getAttribute('sizes')
 
-    expect(sizes).toBe('(max-width: 500px) 500px, 900px')
+    expect(sizes).toBe('(max-width: 200px) 200px, (max-width: 500px) 500px, 900px')
     expect(wrapper.emitted().load[0]).toStrictEqual([loadEvent])
   })
 })

--- a/test/unit/image.test.ts
+++ b/test/unit/image.test.ts
@@ -52,6 +52,37 @@ describe('Renders simple image', () => {
     expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1200x1800/image.png\\" width=\\"200\\" height=\\"300\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 300px) 300px, 400px\\" srcset=\\"/_ipx/s_300x450/image.png 300w, /_ipx/s_400x600/image.png 400w, /_ipx/s_600x900/image.png 600w, /_ipx/s_800x1200/image.png 800w, /_ipx/s_900x1350/image.png 900w, /_ipx/s_1200x1800/image.png 1200w\\">"')
   })
 
+  it('empty densities (fallback to global)', () => {
+    const img = mountImage({
+      width: 200,
+      height: 300,
+      sizes: '300:300px,400:400px',
+      densities: '',
+      src: 'image.png'
+    })
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_800x1200/image.png\\" width=\\"200\\" height=\\"300\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 300px) 300px, 400px\\" srcset=\\"/_ipx/s_300x450/image.png 300w, /_ipx/s_400x600/image.png 400w, /_ipx/s_600x900/image.png 600w, /_ipx/s_800x1200/image.png 800w\\">"')
+  })
+
+  it('empty string densities (fallback to global)', () => {
+    const img = mountImage({
+      width: 200,
+      height: 300,
+      sizes: '300:300px,400:400px',
+      densities: ' ',
+      src: 'image.png'
+    })
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_800x1200/image.png\\" width=\\"200\\" height=\\"300\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 300px) 300px, 400px\\" srcset=\\"/_ipx/s_300x450/image.png 300w, /_ipx/s_400x600/image.png 400w, /_ipx/s_600x900/image.png 600w, /_ipx/s_800x1200/image.png 800w\\">"')
+  })
+
+  it('error on invalid densities', () => {
+    expect(() => mountImage({
+      width: 200,
+      height: 300,
+      densities: 'x',
+      src: 'image.png'
+    })).toThrow(Error)
+  })
+
   it('with single sizes entry', () => {
     const img = mountImage({
       src: '/image.png',

--- a/test/unit/picture.test.ts
+++ b/test/unit/picture.test.ts
@@ -46,7 +46,7 @@ describe('Renders simple image', () => {
   it('Matches snapshot', () => {
     expect(wrapper.html()).toMatchInlineSnapshot(`
       "<picture>
-        <source type=\\"image/webp\\" sizes=\\"(max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&s_500x500/image.png 500w, /_ipx/f_webp&s_900x900/image.png 900w, /_ipx/f_webp&s_1000x1000/image.png 1000w, /_ipx/f_webp&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/image.png\\" sizes=\\"(max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_500x500/image.png 500w, /_ipx/f_png&s_900x900/image.png 900w, /_ipx/f_png&s_1000x1000/image.png 1000w, /_ipx/f_png&s_1800x1800/image.png 1800w\\">
+        <source type=\\"image/webp\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&s_200x200/image.png 200w, /_ipx/f_webp&s_400x400/image.png 400w, /_ipx/f_webp&s_500x500/image.png 500w, /_ipx/f_webp&s_900x900/image.png 900w, /_ipx/f_webp&s_1000x1000/image.png 1000w, /_ipx/f_webp&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/image.png\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/image.png 200w, /_ipx/f_png&s_400x400/image.png 400w, /_ipx/f_png&s_500x500/image.png 500w, /_ipx/f_png&s_900x900/image.png 900w, /_ipx/f_png&s_1000x1000/image.png 1000w, /_ipx/f_png&s_1800x1800/image.png 1800w\\">
       </picture>"
     `)
   })
@@ -119,7 +119,7 @@ describe('Renders simple image', () => {
 
   it('sizes', () => {
     const sizes = wrapper.find('source').element.getAttribute('sizes')
-    expect(sizes).toBe('(max-width: 500px) 500px, 900px')
+    expect(sizes).toBe('(max-width: 200px) 200px, (max-width: 500px) 500px, 900px')
   })
 
   it('renders src when svg is passed', () => {
@@ -143,7 +143,7 @@ describe('Renders simple image', () => {
     })
     expect(img.html()).toMatchInlineSnapshot(`
       "<picture>
-        <source type=\\"image/webp\\" sizes=\\"(max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&s_500x500/%E6%B1%89%E5%AD%97.png 500w, /_ipx/f_webp&s_900x900/%E6%B1%89%E5%AD%97.png 900w, /_ipx/f_webp&s_1000x1000/%E6%B1%89%E5%AD%97.png 1000w, /_ipx/f_webp&s_1800x1800/%E6%B1%89%E5%AD%97.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/%E6%B1%89%E5%AD%97.png\\" sizes=\\"(max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_500x500/%E6%B1%89%E5%AD%97.png 500w, /_ipx/f_png&s_900x900/%E6%B1%89%E5%AD%97.png 900w, /_ipx/f_png&s_1000x1000/%E6%B1%89%E5%AD%97.png 1000w, /_ipx/f_png&s_1800x1800/%E6%B1%89%E5%AD%97.png 1800w\\">
+        <source type=\\"image/webp\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&s_200x200/%E6%B1%89%E5%AD%97.png 200w, /_ipx/f_webp&s_400x400/%E6%B1%89%E5%AD%97.png 400w, /_ipx/f_webp&s_500x500/%E6%B1%89%E5%AD%97.png 500w, /_ipx/f_webp&s_900x900/%E6%B1%89%E5%AD%97.png 900w, /_ipx/f_webp&s_1000x1000/%E6%B1%89%E5%AD%97.png 1000w, /_ipx/f_webp&s_1800x1800/%E6%B1%89%E5%AD%97.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/%E6%B1%89%E5%AD%97.png\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/%E6%B1%89%E5%AD%97.png 200w, /_ipx/f_png&s_400x400/%E6%B1%89%E5%AD%97.png 400w, /_ipx/f_png&s_500x500/%E6%B1%89%E5%AD%97.png 500w, /_ipx/f_png&s_900x900/%E6%B1%89%E5%AD%97.png 900w, /_ipx/f_png&s_1000x1000/%E6%B1%89%E5%AD%97.png 1000w, /_ipx/f_png&s_1800x1800/%E6%B1%89%E5%AD%97.png 1800w\\">
       </picture>"
     `)
   })


### PR DESCRIPTION
### Addresses
- [x] Do not fail for single entries of 'sizes' prop
- [x] Do not fail for _non-breakpoint_ entries of 'sizes' prop
- [x] No longer ignore _non-breakpoint_ entries of 'sizes' prop but add to final `img.sizes`
- [x] Fallback to global `image.densities` config when empty/blank string passed as prop
- [x] Error for invalid values passed to 'densities' prop