### PR TITLE
feat: module config `.format`, last entry used for nuxt-image

### DIFF
--- a/docs/content/5.configuration.md
+++ b/docs/content/5.configuration.md
@@ -49,9 +49,12 @@ export default defineNuxtConfig({
 
 Default: `['webp']`
 
-You can use this option to configure the default format for your images used by `<nuxt-picture>`. The available formats are `webp`, `avif`, `jpeg`, `jpg`, `png`, and `gif`. The order of the formats is important, as the first format that is supported by the browser will be used. You can pass multiple values like `['avif', 'webp']`.
+You can use this option to configure the default format for your images used by `<nuxt-picture>` and `<nuxt-image>`. 
+The order of the formats is important, as the first format that is supported by the browser will be used. You can pass multiple values like `['avif', 'webp']`. For `<nuxt-image>` the last element of the array is used.
 
-You can also override this option at the component level by using the [`format` prop.](/components/nuxt-picture#format)
+Available formats are `webp`, `avif`, `jpeg`, `jpg`, `png`, and `gif`.
+
+You can also override this option at the component level by using `format` prop ([<nuxt-image>](/components/nuxt-image#format)|[<nuxt-picture>](/components/nuxt-picture#format)).
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/src/runtime/components/_base.ts
+++ b/src/runtime/components/_base.ts
@@ -96,7 +96,7 @@ export const useBaseImage = (props: ExtractPropTypes<typeof baseImageProps>) => 
       ...props.modifiers,
       width: parseSize(props.width),
       height: parseSize(props.height),
-      format: props.format,
+      format: props.format || $img.options.format.length ? $img.options.format[$img.options.format.length - 1] : undefined,
       quality: props.quality || $img.options.quality,
       background: props.background,
       fit: props.fit

--- a/test/unit/image.test.ts
+++ b/test/unit/image.test.ts
@@ -268,6 +268,26 @@ describe('Renders image, applies module config', () => {
     `)
   })
 
+  it('Module config .format applies, uses last value of array', () => {
+    nuxtApp._img = createImage({
+      ...imageOptions,
+      nuxt: {
+        baseURL: config.app.baseURL
+      },
+      format: ['avif', 'webp']
+    })
+    const img = mount(NuxtImg, {
+      propsData: {
+        src,
+        width: 200,
+        height: 200
+      }
+    })
+    expect(img.html()).toMatchInlineSnapshot(`
+      "<img src=\\"/_ipx/f_webp&s_200x200/image.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" srcset=\\"/_ipx/f_webp&s_200x200/image.png 1x, /_ipx/f_webp&s_400x400/image.png 2x\\">"
+    `)
+  })
+
   it('Module config .quality + props.quality => props.quality applies', () => {
     nuxtApp._img = createImage({
       ...imageOptions,


### PR DESCRIPTION
### Description
WIth #880 a module level config option `format` was added which currently applies to `<nuxt-picture>` only.
This PR extends nuxt-image to use this config parameter as a default/fallback for `<nuxt-image>`.

### TBC
1. The PR is implemented so that the last element of the array value is used as the default format - is this the right approach?
2. Is this OK / should we keep the default value for 

#### References
Solves/completes: https://github.com/nuxt/image/issues/657

### Tasks
- [ ] confirm using the last element of the array value is the way to go
- [ ] adapt failing tests (module config default is `format: ['webp']` -> applies to many tests)