### PR TITLE
feat: Provide height with sizes attribute

### DIFF
--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -143,7 +143,9 @@ function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions): Image
   if (Object.keys(sizes).length > 1) {
     // 'sizes path'
     for (const key in sizes) {
-      const variant = getSizesVariant(key, String(sizes[key]), height, hwRatio, ctx)
+      const _height = sizes[key][1] ? parseSize(sizes[key][1]) : height
+
+      const variant = getSizesVariant(key, sizes[key][0], _height, hwRatio, ctx)
       if (variant === undefined) {
         continue
       }

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -103,17 +103,14 @@ export function parseDensities (input: string | undefined = ''): number[] {
   return densities.filter((value, index) => densities.indexOf(value) === index)
 }
 
-export function parseSizes (input: Record<string, string | number> | string): Record<string, string> {
-  const sizes: Record<string, string> = {}
+export function parseSizes (input: Record<string, string | number> | string): Record<string, string[]> {
+  const sizes: Record<string, string[]> = {}
   // string => object
   if (typeof input === 'string') {
     for (const entry of input.split(/[\s,]+/).filter(e => e)) {
       const s = entry.split(':')
-      if (s.length !== 2) {
-        sizes[s[0].trim()] = s[0].trim()
-      } else {
-        sizes[s[0].trim()] = s[1].trim()
-      }
+
+      sizes[s[0].trim()] = (s.length !== 2 ? s[0].trim() : s[1].trim()).split('_')
     }
   } else {
     Object.assign(sizes, input)


### PR DESCRIPTION
Described a feature with use case in this issue https://github.com/nuxt/image/issues/900

Now you can provide height with `sizes` attribute like this:

`md:114px_114px lg:138px_138px`

or this, short version:

`md:114_114 lg:138_138`

Examples:

Old output:
 `sizes="md:114px lg:138px"`
```html
<img src="/_ipx/w_276/images/colors.jpg"
  sizes="(max-width: 768px) 114px, 138px"
  srcset="/_ipx/w_114/images/colors.jpg 114w, /_ipx/w_138/images/colors.jpg 138w, /_ipx/w_228/images/colors.jpg 228w, /_ipx/w_276/images/colors.jpg 276w"
>
```

New output:
`md:114_114 lg:138_138` with `fit="cover"`
```html
<img 
  src="/_ipx/fit_cover&amp;s_276x276/images/colors.jpg"
  sizes="(max-width: 768px) 114px, 138px"
  srcset="/_ipx/fit_cover&amp;s_114x114/images/colors.jpg 114w, /_ipx/fit_cover&amp;s_138x138/images/colors.jpg 138w, /_ipx/fit_cover&amp;s_228x228/images/colors.jpg 228w, /_ipx/fit_cover&amp;s_276x276/images/colors.jpg 276w"
>
```