### PR TITLE
doc: prefer pascal case for component names

### DIFF
--- a/docs/content/1.index.md
+++ b/docs/content/1.index.md
@@ -27,8 +27,8 @@ Plug-and-play image optimization for Nuxt apps. Resize and transform your images
 
 #extra
   ::list
-  - [`<nuxt-img>`](/components/nuxt-img) drop-in replacement for the native `<img>` element
-  - [`<nuxt-picture>`](/components/nuxt-picture) drop-in replacement for the native `<picture>` element.
+  - [`<NuxtImg>`](/components/nuxt-img) drop-in replacement for the native `<img>` element
+  - [`<NuxtPicture>`](/components/nuxt-picture) drop-in replacement for the native `<picture>` element.
   - Built-in image resizer and transformer with [unjs/ipx](https://github.com/unjs/ipx)
   - Support [18+ providers](/providers/cloudflare)
   - Generate responsive sizes

--- a/docs/content/2.get-started.md
+++ b/docs/content/2.get-started.md
@@ -36,7 +36,7 @@ export default defineNuxtConfig({
 ```
 
 ::alert{type="success"}
-You can now start using [`<nuxt-img>`](/components/nuxt-img) and [`<nuxt-picture>`](/components/nuxt-picture) components in your Nuxt app ✨
+You can now start using [`<NuxtImg>`](/components/nuxt-img) and [`<NuxtPicture>`](/components/nuxt-picture) components in your Nuxt app ✨
 ::
 
 ## Configuration

--- a/docs/content/3.components/1.nuxt-img.md
+++ b/docs/content/3.components/1.nuxt-img.md
@@ -1,8 +1,8 @@
-# `<nuxt-img>`
+# `<NuxtImg>`
 
 Discover how to use and configure the nuxt-img component.
 
-`<nuxt-img>` is a drop-in replacement for the native `<img>` tag.
+`<NuxtImg>` is a drop-in replacement for the native `<img>` tag.
 
 ::list
 - Uses built-in provider to optimize local and remote images
@@ -17,7 +17,7 @@ Discover how to use and configure the nuxt-img component.
 `nuxt-img` outputs a native `img` tag directly (without any wrapper around it). Use it like you would use the `<img>` tag:
 
 ```html
-<nuxt-img src="/nuxt-icon.png" />
+<NuxtImg src="/nuxt-icon.png" />
 ```
 
 Will result in:
@@ -40,7 +40,7 @@ Path to image file
 Otherwise path that is expected by provider that starts with `/` or a URL.
 
 ```html
-<nuxt-img src="/nuxt.png" />
+<NuxtImg src="/nuxt.png" />
 ```
 
 For image optimization when using external urls in `src`, we need to whitelist them using [`domains`](/configuration#domains) option.
@@ -61,7 +61,7 @@ This a space-separated list of screen size/width pairs. You can [see a list of t
 **Example:**
 
 ```html
-<nuxt-img
+<NuxtImg
   src="/logos/nuxt.png"
   sizes="sm:100vw md:50vw lg:400px"
   />
@@ -74,7 +74,7 @@ To generate special versions of images for screens with increased pixel density.
 **Example:**
 
 ```html
-<nuxt-img
+<NuxtImg
   src="/logos/nuxt.png"
   height="50"
   densities="x1 x2"
@@ -93,7 +93,7 @@ Use other provider instead of default [provider option](/configuration#provider)
 
   ```html [index.vue]
   <template>
-    <nuxt-img
+    <NuxtImg
       provider="cloudinary"
       src="/remote/nuxt-org/blog/going-full-static/main.png"
       width="300"
@@ -127,7 +127,7 @@ Presets are predefined sets of image modifiers that can be used create unified f
 
   ```html [index.vue]
   <template>
-    <nuxt-img preset="cover" src="/nuxt-icon.png" />
+    <NuxtImg preset="cover" src="/nuxt-icon.png" />
   </template>
   ```
 
@@ -156,7 +156,7 @@ Presets are predefined sets of image modifiers that can be used create unified f
 In case you want to serve images in a specific format, use this prop.
 
 ```html
-<nuxt-img format="webp" src="/nuxt-icon.png" ... />
+<NuxtImg format="webp" src="/nuxt-icon.png" ... />
 ```
 
 Available formats are `webp`, `avif`, `jpeg`, `jpg`, `png`, `gif` and `svg`. If the format is not specified, it will respect the default image format.
@@ -166,7 +166,7 @@ Available formats are `webp`, `avif`, `jpeg`, `jpg`, `png`, `gif` and `svg`. If 
 The quality for the generated image(s).
 
 ```html
-<nuxt-img src="/nuxt.jpg" quality="80" width="200" height="100" />
+<NuxtImg src="/nuxt.jpg" quality="80" width="200" height="100" />
 ```
 
 ### `fit`
@@ -181,7 +181,7 @@ There are five standard values you can use with this property.
 - `outside`: Preserving aspect ratio, resize the image to be as small as possible while ensuring its dimensions are greater than or equal to both those specified.
 
 ```html
-<nuxt-img fit="cover" src="/nuxt-icon.png" width="200" height="100" />
+<NuxtImg fit="cover" src="/nuxt-icon.png" width="200" height="100" />
 ```
 
 ::alert{type="info"}
@@ -197,7 +197,7 @@ Using the `modifiers` prop lets you use any of these transformations.
 **Example:**
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="cloudinary"
   src="/remote/nuxt-org/blog/going-full-static/main.png"
   width="300"
@@ -211,7 +211,7 @@ Using the `modifiers` prop lets you use any of these transformations.
 In case you want to preload the image, use this prop. This will place a corresponding `link` tag in the page's head.
 
 ```html
-<nuxt-img preload src="/nuxt-icon.png" />
+<NuxtImg preload src="/nuxt-icon.png" />
 ```
 
 ### `loading`
@@ -223,18 +223,18 @@ It is [supported](https://caniuse.com/loading-lazy-attr) by the latest version o
 Set `loading="lazy"` to defer loading of an image until it appears in the viewport.
 
 ```html
-<nuxt-img src="/nuxt-icon.png" loading="lazy" />
+<NuxtImg src="/nuxt-icon.png" loading="lazy" />
 ```
 
 
 ## Events
 
-Native events emitted by the `<img>` element contained by `<nuxt-img>` and `<nuxt-picture>` components are re-emitted and can be listened to.
+Native events emitted by the `<img>` element contained by `<NuxtImg>` and `<NuxtPicture>` components are re-emitted and can be listened to.
 
-**Example:** Listen to the native `onLoad` event from `<nuxt-img>`
+**Example:** Listen to the native `onLoad` event from `<NuxtImg>`
 
 ```html
-<nuxt-img
+<NuxtImg
   src="/images/colors.jpg"
   width="500"
   height="500"

--- a/docs/content/3.components/2.nuxt-picture.md
+++ b/docs/content/3.components/2.nuxt-picture.md
@@ -1,17 +1,17 @@
-# `<nuxt-picture>`
+# `<NuxtPicture>`
 
 Discover how to use and configure the nuxt-picture component.
 
-`<nuxt-picture>` is a drop-in replacement for the native `<picture>` tag.
+`<NuxtPicture>` is a drop-in replacement for the native `<picture>` tag.
 
-Usage of `<nuxt-picture>` is almost identical to [`<nuxt-img>`](nuxt-img) but also allows serving modern formats like `webp` when possible.
+Usage of `<NuxtPicture>` is almost identical to [`<NuxtImg>`](nuxt-img) but also allows serving modern formats like `webp` when possible.
 
 Learn more about the [`<picture>` tag on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/picture).
 
 ## Props
 
 ::alert{type="info"}
- See props supported by[`<nuxt-img>`](/components/nuxt-img#props)</a>
+ See props supported by[`<NuxtImg>`](/components/nuxt-img#props)</a>
 ::
 
 ### `format`
@@ -19,7 +19,7 @@ Learn more about the [`<picture>` tag on MDN](https://developer.mozilla.org/en-U
 Format on pictures can be used to serve images in multiple formats. A legacy format will be generated automatically. So in the example below avif, webp and png would be generated. They will be added in the same order they are added to the format attribute.
 
 ```html
-<nuxt-picture format="avif,webp" src="/nuxt-icon.png" ... />
+<NuxtPicture format="avif,webp" src="/nuxt-icon.png" ... />
 ```
 
 Available formats are `webp`, `avif`, `jpeg`, `jpg`, `png` and `gif`. If the format is not specified, it will respect the default image format.
@@ -38,8 +38,8 @@ Allows you to set additional HTML-attributes on the `img` element.
 **Example:**
 
 ```html
-<nuxt-picture
+<NuxtPicture
   src="/nuxt-icon.png"
-  :imgAttrs="{id:'my-id', class:'my-class', style:'display:block', 'data-my-data': 'my-value'}"
+  :img-attrs="{id:'my-id', class:'my-class', style:'display:block', 'data-my-data': 'my-value'}"
 />
 ```

--- a/docs/content/4.api/2.use-image.md
+++ b/docs/content/4.api/2.use-image.md
@@ -4,7 +4,7 @@ aside: false
 
 # `useImage` composable
 
-Sometimes you might need to use a generated image URL directly with applied transformations instead of the `<nuxt-img>` and `<nuxt-picture>` components. This is where `useImage()` comes in (and the helper function it returns, which you will often see referenced directly as `$img` or `img`).
+Sometimes you might need to use a generated image URL directly with applied transformations instead of the `<NuxtImg>` and `<NuxtPicture>` components. This is where `useImage()` comes in (and the helper function it returns, which you will often see referenced directly as `$img` or `img`).
 
 ## Usage
 

--- a/docs/content/5.configuration.md
+++ b/docs/content/5.configuration.md
@@ -49,7 +49,7 @@ export default defineNuxtConfig({
 
 Default: `['webp']`
 
-You can use this option to configure the default format for your images used by `<nuxt-picture>`. The available formats are `webp`, `avif`, `jpeg`, `jpg`, `png`, and `gif`. The order of the formats is important, as the first format that is supported by the browser will be used. You can pass multiple values like `['avif', 'webp']`.
+You can use this option to configure the default format for your images used by `<NuxtPicture>`. The available formats are `webp`, `avif`, `jpeg`, `jpg`, `png`, and `gif`. The order of the formats is important, as the first format that is supported by the browser will be used. You can pass multiple values like `['avif', 'webp']`.
 
 You can also override this option at the component level by using the [`format` prop.](/components/nuxt-picture#format)
 
@@ -118,7 +118,7 @@ export default defineNuxtConfig({
 ```
 ```html [index.vue]
 <template>
-  <nuxt-img preset="avatar" src="/nuxt-icon.png" />
+  <NuxtImg preset="avatar" src="/nuxt-icon.png" />
 </template>
 ```
 ::
@@ -143,7 +143,7 @@ export default defineNuxtConfig({
 ```
 ```vue [index.vue]
 <template>
-  <nuxt-img provider="random" src="main.png" width="300" height="169" />
+  <NuxtImg provider="random" src="main.png" width="300" height="169" />
 </template>
 ```
 ::
@@ -248,7 +248,7 @@ export default defineNuxtConfig({
 **Before** using alias:
 
 ```html
-<nuxt-img src="https://images.unsplash.com/<id>" />
+<NuxtImg src="https://images.unsplash.com/<id>" />
 ```
 
 Generates:
@@ -261,7 +261,7 @@ Generates:
 
 
 ```html
-<nuxt-img src="/unsplash/<id>" />
+<NuxtImg src="/unsplash/<id>" />
 ```
 
 Generates:

--- a/docs/content/5.providers/0.introduction.md
+++ b/docs/content/5.providers/0.introduction.md
@@ -12,7 +12,7 @@ Nuxt Image can be configured to work with any external image transformation serv
 
 If you are looking for a specific provider that is not already supported, you can [create your own provider](/advanced/custom-provider).
 
-Nuxt Image will automatically optimize `<nuxt-img>` or `<nuxt-picture>` sources and accepts all [options](/configuration) for specified target, except for modifiers that are specific to other providers.
+Nuxt Image will automatically optimize `<NuxtImg>` or `<NuxtPicture>` sources and accepts all [options](/configuration) for specified target, except for modifiers that are specific to other providers.
 
 ## Default Provider
 
@@ -22,7 +22,7 @@ The default optimizer and provider for Nuxt Image is [ipx](/providers/ipx). Eith
 
 Images should be stored in the `public/` directory of your project.
 
-For example, when using `<nuxt-img src="/nuxt-icon.png" />`, it should be placed in `public/` folder under the path `public/nuxt-icon.png`.
+For example, when using `<NuxtImg src="/nuxt-icon.png" />`, it should be placed in `public/` folder under the path `public/nuxt-icon.png`.
 
 For more information, you can learn more about the [public directory](https://nuxt.com/docs/guide/directory-structure/public).
 

--- a/docs/content/5.providers/cloudflare.md
+++ b/docs/content/5.providers/cloudflare.md
@@ -19,7 +19,7 @@ export default defineNuxtConfig({
 **Example:**
 
 ```vue
-<nuxt-img provider="cloudflare" src="/burger.jpeg" height="300" :modifiers="{ fit: 'contain' }" />
+<NuxtImg provider="cloudflare" src="/burger.jpeg" height="300" :modifiers="{ fit: 'contain' }" />
 ```
 
 ## Options

--- a/docs/content/5.providers/cloudinary.md
+++ b/docs/content/5.providers/cloudinary.md
@@ -96,7 +96,7 @@ Round the specified corners of the desired image. If pass only a number or `max`
 * Using 4 values: `top_left:top_right:bottom_left:bottom_right` (Example: `20:0:40:40`)
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="cloudinary"
   src="/remote/nuxt-org/blog/going-full-static/main.png"
   width="300"
@@ -111,7 +111,7 @@ Detemine which part of the image to cropped or to place the overlay.
 Accepted values: `auto`, `subject`, `face`, `sink`, `faceCenter`, `multipleFaces`, `multipleFacesCenter`, `north`, `northEast`, `northWest`, `west`, `southWest`, `south`, `southEast`, `east`, `center`
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="cloudinary"
   src="/remote/nuxt-org/blog/going-full-static/main.png"
   width="300"
@@ -126,7 +126,7 @@ Accepted values: `auto`, `subject`, `face`, `sink`, `faceCenter`, `multipleFaces
 Apply a filter or an effect on the desired asset. See [Effects for images](https://cloudinary.com/documentation/image_transformation_reference#effect_parameter) for the full list of syntax and available effects.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="cloudinary"
   src="/remote/nuxt-org/blog/going-full-static/main.png"
   width="300"
@@ -141,7 +141,7 @@ Apply a filter or an effect on the desired asset. See [Effects for images](https
 Color to use when text captions, shadow effect and colorize effect are in use.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="cloudinary"
   src="/remote/nuxt-org/blog/going-full-static/main.png"
   width="300"
@@ -162,7 +162,7 @@ The target device pixel ratio for the asset. `auto` means automatically matching
 Adjust the opacity of the desired image. Scale: 0 to 100 (%).
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="cloudinary"
   src="/remote/nuxt-org/blog/going-full-static/main.png"
   width="300"
@@ -175,7 +175,7 @@ Adjust the opacity of the desired image. Scale: 0 to 100 (%).
 Create a layer **over** the base image. This can be use with `x`, `y`, `gravity` to customize the position of the overlay.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="cloudinary"
   src="/remote/nuxt-org/blog/going-full-static/main.png"
   width="100"
@@ -214,7 +214,7 @@ Use together with `fit='crop'` or `fit='thumb'` to decide how much of original i
 
 ```html [index.vue]
 <template>
-  <nuxt-img
+  <NuxtImg
     provider="cloudinary"
     src="/remote/nuxt-org/blog/going-full-static/main.png"
     width="100"
@@ -243,7 +243,7 @@ Use together with `fit='crop'` or `fit='thumb'` to decide how much of original i
 Color space to use for the delivery image url. See [Color space Documentation](https://cloudinary.com/documentation/image_transformation_reference#color_space_parameter) for accepted values details.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="cloudinary"
   src="/remote/nuxt-org/blog/going-full-static/main.png"
   width="300"

--- a/docs/content/5.providers/directus.md
+++ b/docs/content/5.providers/directus.md
@@ -37,7 +37,7 @@ export default defineNuxtConfig({
 All the default modifiers from [Directus documentation](https://docs.directus.io/reference/files.html#requesting-a-thumbnail) are available.
 
 ```vue
-<nuxt-img
+<NuxtImg
   provider="directus"
   src="ad514db1-eb90-4523-8183-46781437e7ee"
   height="512"
@@ -50,7 +50,7 @@ All the default modifiers from [Directus documentation](https://docs.directus.io
 Since Directus exposes [the full sharp API](https://sharp.pixelplumbing.com/api-operation) through the `transforms` parameter, we can use it inside our `modifiers` prop:
 
 ```vue
-<nuxt-img
+<NuxtImg
   provider="directus"
   src="ad514db1-eb90-4523-8183-46781437e7ee"
   :modifiers="{ height: '512', withoutEnlargement: 'true', transforms: [['blur', 4], ['negate']] }"

--- a/docs/content/5.providers/edgio.md
+++ b/docs/content/5.providers/edgio.md
@@ -13,7 +13,7 @@ This integration works out of the box without need to configure!  See the [Docum
 **Example:**
 
 ```vue
-<nuxt-img provider="edgio" src="https://i.imgur.com/LFtQeX2.jpeg" width="200" height="200" quality="80" />
+<NuxtImg provider="edgio" src="https://i.imgur.com/LFtQeX2.jpeg" width="200" height="200" quality="80" />
 ```
 
 ## Modifiers

--- a/docs/content/5.providers/gumlet.md
+++ b/docs/content/5.providers/gumlet.md
@@ -32,7 +32,7 @@ For a full list of these modifiers and their uses, check out [Gumlet's image Ren
 Some common best practices when using Gumlet, would be to include our `format=auto` parameter, which will automatically apply the best format for an image and compress the image as well. Combine this with some top of intelligent cropping and resizing and you will have a great image!
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="gumlet"
   src="/sea.jpeg"
   width="300"

--- a/docs/content/5.providers/imageengine.md
+++ b/docs/content/5.providers/imageengine.md
@@ -45,7 +45,7 @@ In addition to the [standard modifiers](/components/nuxt-img#modifiers), you can
 Example 1: Cropping an image to a width and height of 100x80, starting 10 pixels from the top and 20 pixels from the left:
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imageengine"
   src="/some-image.jpg"
   width="100"
@@ -57,7 +57,7 @@ Example 1: Cropping an image to a width and height of 100x80, starting 10 pixels
 Example 2: Instruct ImageEngine to keep the image's EXIF metadata (which is normally removed to reduce the image byte size):
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imageengine"
   src="/some-image.jpg"
   width="100"

--- a/docs/content/5.providers/imagekit.md
+++ b/docs/content/5.providers/imagekit.md
@@ -47,7 +47,7 @@ Check out ImageKit's documentation on [focus](https://docs.imagekit.io/features/
 This can be used to blur an image. Use modifier `blur` to specify the Gaussian Blur radius that is to be applied to the image. Possible values include integers between `1` to `100`.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imagekit"
   src="/default-image.jpg"
   :modifiers="{blur: 10}"
@@ -60,7 +60,7 @@ This can be used to blur an image. Use modifier `blur` to specify the Gaussian B
 Turn your image to a grayscale version using the `effectGray` modifier.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imagekit"
   src="/default-image.jpg"
   height="300"
@@ -81,7 +81,7 @@ For example, we can create a named transformation - `media_library_thumbnail` fo
 Add a border to your images using the `border` modifier. You can also set its width and color.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imagekit"
   src="/default-image.jpg"
   width="300"
@@ -95,7 +95,7 @@ Add a border to your images using the `border` modifier. You can also set its wi
 Use the `rotate` modifier to rotate your image. Possible values are - `0`, `90`, `180`, `270`, `360`, and `auto`.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imagekit"
   src="/default-image.jpg"
   :modifiers="{rotate: 90}"
@@ -108,7 +108,7 @@ Use the `rotate` modifier to rotate your image. Possible values are - `0`, `90`,
 Give rounded corners to your image using `radius`. Possible values are - positive integers and `max`.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imagekit"
   src="/default-image.jpg"
   :modifiers="{radius: 20}"
@@ -121,7 +121,7 @@ Give rounded corners to your image using `radius`. Possible values are - positiv
 Specify background color and its opacity for your image using the `bg` modifier.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imagekit"
   src="/default-image.jpg"
   height="1200"
@@ -141,7 +141,7 @@ Using ImageKit's Nuxt Image integration, you can overlay images or text over oth
 Overlay an image on top of another image (base image) using the `overlayImage` modifier. You can use this to create dynamic banners, watermarking, etc.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imagekit"
   src="/default-image.jpg"
   :modifiers="modifiers"
@@ -169,7 +169,7 @@ Overlay an image on top of another image (base image) using the `overlayImage` m
 You can overlay text on an image and apply various transformations to it as per your needs.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imagekit"
   src="/default-image.jpg"
   :modifiers="modifiers"
@@ -201,7 +201,7 @@ Read more about ImageKit's overlay transformation parameters [here](https://docs
 Enhance contrast of an image using the `effectContrast` modifier.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imagekit"
   src="/default-image.jpg"
   height="300"
@@ -213,7 +213,7 @@ Enhance contrast of an image using the `effectContrast` modifier.
 Sharpen the input image using the `effectSharpen` modifier.
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imagekit"
   src="/default-image.jpg"
   height="300"

--- a/docs/content/5.providers/imgix.md
+++ b/docs/content/5.providers/imgix.md
@@ -39,7 +39,7 @@ For a full list of these modifiers and their uses, check out [imgix's image Rend
 Some common best practices when using imgix, would be to include our auto parameter, which will automatically apply the best format for an image and compress the image as well.  Combine this with some top of intelligent cropping and resizing and you will have a great image!
 
 ```html
-<nuxt-img
+<NuxtImg
   provider="imgix"
   src="/blog/woman-hat.jpg"
   width="300"

--- a/docs/content/5.providers/ipx.md
+++ b/docs/content/5.providers/ipx.md
@@ -11,5 +11,5 @@ You can use [additional modifiers](https://github.com/unjs/ipx/#modifiers) suppo
 **Example:**
 
 ```html
-<nuxt-img src="/image.png" :modifiers="{ grayscale: true, tint: '#00DC82' }" />
+<NuxtImg src="/image.png" :modifiers="{ grayscale: true, tint: '#00DC82' }" />
 ```

--- a/docs/content/5.providers/prismic.md
+++ b/docs/content/5.providers/prismic.md
@@ -17,7 +17,7 @@ export default defineNuxtConfig({
 You can also pass it directly to your component when you need it, for example:
 
 ```html[*.vue]
-<nuxt-img provider="prismic" src="..." />
+<NuxtImg provider="prismic" src="..." />
 ```
 
 ::alert{type="info"}

--- a/docs/content/5.providers/strapi.md
+++ b/docs/content/5.providers/strapi.md
@@ -42,12 +42,12 @@ You can override the default breakpoints. See the [Upload configuration](https:/
 If you don't set breakpoint modifier, the original image size will be used:
 
 ```html
-<nuxt-img provider="strapi" src="..." />
+<NuxtImg provider="strapi" src="..." />
 ```
 
 Define breakpoint modifier:
 ```html
-<nuxt-img provider="strapi" src="..." :modifiers="{ breakpoint: 'small' }" />
+<NuxtImg provider="strapi" src="..." :modifiers="{ breakpoint: 'small' }" />
 ```
 
 ::alert{type="info"}

--- a/docs/content/5.providers/vercel.md
+++ b/docs/content/5.providers/vercel.md
@@ -24,7 +24,7 @@ export default {
 
 ## Sizes
 
-Specify any custom `width` property you use in `<nuxt-img>`, `<nuxt-picture>` and `$img`.
+Specify any custom `width` property you use in `<NuxtImg>`, `<NuxtPicture>` and `$img`.
 
 If a width is not defined, image will fallback to closest possible width.
 


### PR DESCRIPTION
More consistent with the Vue style guide: https://vuejs.org/guide/components/registration.html#component-name-casing