### PR TITLE
fix: warn in dev mode if density is provided above 2x

### DIFF
--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -132,12 +132,7 @@ function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions): Image
   const height = parseSize(opts.modifiers?.height)
   const sizes = parseSizes(opts.sizes)
   const densities = opts.densities?.trim() ? parseDensities(opts.densities.trim()) : ctx.options.densities
-  if (densities.length === 0) {
-    throw new Error('\'densities\' must not be empty, configure to \'1\' to render regular size only (DPR 1.0)')
-  }
-  if (process.dev) {
-    checkDensities(densities)
-  }
+  checkDensities(densities)
 
   const hwRatio = (width && height) ? height / width : 0
   const sizeVariants = []

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -3,7 +3,7 @@ import { hasProtocol, parseURL, joinURL, withLeadingSlash } from 'ufo'
 import type { ImageOptions, ImageSizesOptions, CreateImageOptions, ResolvedImage, ImageCTX, $Img } from '../types/image'
 import { ImageSizes, ImageSizesVariant } from '../types/image'
 import { imageMeta } from './utils/meta'
-import { parseDensities, parseSize, parseSizes } from './utils'
+import { checkDensities, parseDensities, parseSize, parseSizes } from './utils'
 import { prerenderStaticImages } from './utils/prerender'
 
 export function createImage (globalOptions: CreateImageOptions) {
@@ -134,6 +134,9 @@ function getSizes (ctx: ImageCTX, input: string, opts: ImageSizesOptions): Image
   const densities = opts.densities?.trim() ? parseDensities(opts.densities.trim()) : ctx.options.densities
   if (densities.length === 0) {
     throw new Error('\'densities\' must not be empty, configure to \'1\' to render regular size only (DPR 1.0)')
+  }
+  if (process.dev) {
+    checkDensities(densities)
   }
 
   const hwRatio = (width && height) ? height / width : 0

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -108,7 +108,7 @@ export function parseDensities (input: string | undefined = ''): number[] {
 
 export function checkDensities (densities: number[]) {
   if (densities.length === 0) {
-    throw new Error('\'densities\' must not be empty, configure to \'1\' to render regular size only (DPR 1.0)')
+    throw new Error('`densities` must not be empty, configure to `1` to render regular size only (DPR 1.0)')
   }
   if (process.dev && Array.from(densities).some(d => d > 2)) {
     console.warn('[nuxt] [image] Density values above `2` are not recommended. See https://observablehq.com/@eeeps/visual-acuity-and-device-pixel-ratio.')

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -99,10 +99,8 @@ export function parseDensities (input: string | undefined = ''): number[] {
 
   const densities = new Set<number>()
   for (const density of input.split(' ')) {
-    const d = parseInt(density.replace('x', ''), 10)
-    if (d) {
-      densities.add(d)
-    }
+    const d = parseInt(density.replace('x', ''))
+    if (d) { densities.add(d) }
   }
 
   return Array.from(densities)

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -97,10 +97,21 @@ export function parseDensities (input: string | undefined = ''): number[] {
     return []
   }
 
-  const densities = input.split(' ').map(size => parseInt(size.replace('x', '')))
+  const densities = new Set<number>()
+  for (const density of input.split(' ')) {
+    const d = parseInt(density.replace('x', ''), 10)
+    if (d) {
+      densities.add(d)
+    }
+  }
 
-  // de-duplicate and return
-  return densities.filter((value, index) => densities.indexOf(value) === index)
+  return Array.from(densities)
+}
+
+export function checkDensities (densities: number[]) {
+  if (process.dev && Array.from(densities).some(d => d > 2)) {
+    console.warn('[nuxt] [image] Density values above 2 are not recommended. See https://observablehq.com/@eeeps/visual-acuity-and-device-pixel-ratio.')
+  }
 }
 
 export function parseSizes (input: Record<string, string | number> | string): Record<string, string> {

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -111,7 +111,7 @@ export function checkDensities (densities: number[]) {
     throw new Error('\'densities\' must not be empty, configure to \'1\' to render regular size only (DPR 1.0)')
   }
   if (process.dev && Array.from(densities).some(d => d > 2)) {
-    console.warn('[nuxt] [image] Density values above 2 are not recommended. See https://observablehq.com/@eeeps/visual-acuity-and-device-pixel-ratio.')
+    console.warn('[nuxt] [image] Density values above `2` are not recommended. See https://observablehq.com/@eeeps/visual-acuity-and-device-pixel-ratio.')
   }
 }
 

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -107,6 +107,9 @@ export function parseDensities (input: string | undefined = ''): number[] {
 }
 
 export function checkDensities (densities: number[]) {
+  if (densities.length === 0) {
+    throw new Error('\'densities\' must not be empty, configure to \'1\' to render regular size only (DPR 1.0)')
+  }
   if (process.dev && Array.from(densities).some(d => d > 2)) {
     console.warn('[nuxt] [image] Density values above 2 are not recommended. See https://observablehq.com/@eeeps/visual-acuity-and-device-pixel-ratio.')
   }


### PR DESCRIPTION
resolves https://github.com/nuxt/image/issues/912

This PR warns in dev mode if user is setting a density > 2x, linking to https://observablehq.com/@eeeps/visual-acuity-and-device-pixel-ratio.

It doesn't hard-disable this although this might be something we consider in future.

This also refactors the density parsing expression slightly to use a Set for deduplicating.