### PR TITLE
feat!: switch `sizes` default to responsive-first

### DIFF
--- a/docs/content/2.usage/1.nuxt-img.md
+++ b/docs/content/2.usage/1.nuxt-img.md
@@ -55,15 +55,20 @@ Specify width/height of the image.
 
 Specify responsive sizes.
 
-This a space-separated list of screen size/width pairs. You can [see a list of the defined screen sizes here](/get-started/configuration#screens)).
+This is a space-separated list of screen size/width pairs. You can [see a list of the defined screen sizes here](/get-started/configuration#screens)).
+
+By default Nuxt generates _responsive-first_ sizing.
+
+- If you omit a screen size prefix (like `sm:`) then this size is the 'default' size of the image. Otherwise, Nuxt will pick the smallest size as the default size of the image.
+- This default size is used up until the next specified screen width, and so on. Each specified size pair applies _up_ - so `md:400px` means that the image will be sized `400px` on `md` screens and up.
 
 **Example:**
 
 ```html
 <NuxtImg
   src="/logos/nuxt.png"
-  sizes="sm:100vw md:50vw lg:400px"
-  />
+  sizes="100vw sm:50vw md:400px"
+/>
 ```
 
 ### `densities`
@@ -77,12 +82,12 @@ To generate special versions of images for screens with increased pixel density.
   src="/logos/nuxt.png"
   height="50"
   densities="x1 x2"
-  />
+/>
 <!--
 <img
   src="/_ipx/w_50/logos/nuxt.png" 
   srcset="/_ipx/w_100/logos/nuxt.png x2"
-  />
+/>
 -->
 ```
 

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -240,11 +240,6 @@ function getVariantSrc (ctx: ImageCTX, input: string, opts: ImageSizesOptions, v
 function finaliseSizeVariants (sizeVariants: any[]) {
   sizeVariants.sort((v1, v2) => v1.screenMaxWidth - v2.screenMaxWidth)
 
-  // for last size variant, always remove `media` (convention)
-  if (sizeVariants[sizeVariants.length - 1]) {
-    sizeVariants[sizeVariants.length - 1].media = ''
-  }
-
   // de-duplicate size variants (by key `media`)
   let previousMedia = null
   for (let i = sizeVariants.length - 1; i >= 0; i--) {
@@ -253,6 +248,10 @@ function finaliseSizeVariants (sizeVariants: any[]) {
       sizeVariants.splice(i, 1)
     }
     previousMedia = sizeVariant.media
+  }
+
+  for (let i = 0; i < sizeVariants.length; i++) {
+    sizeVariants[i].media = sizeVariants[i + 1]?.media || ''
   }
 }
 

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -122,7 +122,7 @@ export function parseSizes (input: Record<string, string | number> | string): Re
     for (const entry of input.split(/[\s,]+/).filter(e => e)) {
       const s = entry.split(':')
       if (s.length !== 2) {
-        sizes[s[0].trim()] = s[0].trim()
+        sizes['1px'] = s[0].trim()
       } else {
         sizes[s[0].trim()] = s[1].trim()
       }

--- a/test/unit/image.test.ts
+++ b/test/unit/image.test.ts
@@ -21,7 +21,7 @@ describe('Renders simple image', () => {
   })
 
   it('Matches snapshot', () => {
-    expect(wrapper.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1800x1800/image.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/s_200x200/image.png 200w, /_ipx/s_400x400/image.png 400w, /_ipx/s_500x500/image.png 500w, /_ipx/s_900x900/image.png 900w, /_ipx/s_1000x1000/image.png 1000w, /_ipx/s_1800x1800/image.png 1800w\\">"')
+    expect(wrapper.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1800x1800/image.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/s_200x200/image.png 200w, /_ipx/s_400x400/image.png 400w, /_ipx/s_500x500/image.png 500w, /_ipx/s_900x900/image.png 900w, /_ipx/s_1000x1000/image.png 1000w, /_ipx/s_1800x1800/image.png 1800w\\">"')
   })
 
   it('props.src is picked up by getImage()', () => {
@@ -40,7 +40,7 @@ describe('Renders simple image', () => {
 
   it('sizes', () => {
     const sizes = wrapper.find('img').element.getAttribute('sizes')
-    expect(sizes).toBe('(max-width: 200px) 200px, (max-width: 500px) 500px, 900px')
+    expect(sizes).toMatchInlineSnapshot('"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px"')
   })
 
   it('applies densities', () => {
@@ -51,7 +51,7 @@ describe('Renders simple image', () => {
       densities: '1x 2x 3x',
       src: 'image.png'
     })
-    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1200x1800/image.png\\" width=\\"200\\" height=\\"300\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 300px) 300px, 400px\\" srcset=\\"/_ipx/s_300x450/image.png 300w, /_ipx/s_400x600/image.png 400w, /_ipx/s_600x900/image.png 600w, /_ipx/s_800x1200/image.png 800w, /_ipx/s_900x1350/image.png 900w, /_ipx/s_1200x1800/image.png 1200w\\">"')
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1200x1800/image.png\\" width=\\"200\\" height=\\"300\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 400px) 300px, 400px\\" srcset=\\"/_ipx/s_300x450/image.png 300w, /_ipx/s_400x600/image.png 400w, /_ipx/s_600x900/image.png 600w, /_ipx/s_800x1200/image.png 800w, /_ipx/s_900x1350/image.png 900w, /_ipx/s_1200x1800/image.png 1200w\\">"')
   })
 
   it('empty densities (fallback to global)', () => {
@@ -62,7 +62,7 @@ describe('Renders simple image', () => {
       densities: '',
       src: 'image.png'
     })
-    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_800x1200/image.png\\" width=\\"200\\" height=\\"300\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 300px) 300px, 400px\\" srcset=\\"/_ipx/s_300x450/image.png 300w, /_ipx/s_400x600/image.png 400w, /_ipx/s_600x900/image.png 600w, /_ipx/s_800x1200/image.png 800w\\">"')
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_800x1200/image.png\\" width=\\"200\\" height=\\"300\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 400px) 300px, 400px\\" srcset=\\"/_ipx/s_300x450/image.png 300w, /_ipx/s_400x600/image.png 400w, /_ipx/s_600x900/image.png 600w, /_ipx/s_800x1200/image.png 800w\\">"')
   })
 
   it('empty string densities (fallback to global)', () => {
@@ -73,7 +73,7 @@ describe('Renders simple image', () => {
       densities: ' ',
       src: 'image.png'
     })
-    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_800x1200/image.png\\" width=\\"200\\" height=\\"300\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 300px) 300px, 400px\\" srcset=\\"/_ipx/s_300x450/image.png 300w, /_ipx/s_400x600/image.png 400w, /_ipx/s_600x900/image.png 600w, /_ipx/s_800x1200/image.png 800w\\">"')
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_800x1200/image.png\\" width=\\"200\\" height=\\"300\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 400px) 300px, 400px\\" srcset=\\"/_ipx/s_300x450/image.png 300w, /_ipx/s_400x600/image.png 400w, /_ipx/s_600x900/image.png 600w, /_ipx/s_800x1200/image.png 800w\\">"')
   })
 
   it('error on invalid densities', () => {
@@ -112,7 +112,7 @@ describe('Renders simple image', () => {
       sizes: '200:200px,300:200px,400:400px,400:400px,500:500px,800:800px',
       src: 'image.png'
     })
-    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1600x2400/image.png\\" width=\\"200\\" height=\\"300\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 200px) 200px, (max-width: 300px) 200px, (max-width: 400px) 400px, (max-width: 500px) 500px, 800px\\" srcset=\\"/_ipx/s_200x300/image.png 200w, /_ipx/s_400x600/image.png 400w, /_ipx/s_500x750/image.png 500w, /_ipx/s_800x1200/image.png 800w, /_ipx/s_1000x1500/image.png 1000w, /_ipx/s_1600x2400/image.png 1600w\\">"')
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1600x2400/image.png\\" width=\\"200\\" height=\\"300\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 300px) 200px, (max-width: 400px) 200px, (max-width: 500px) 400px, (max-width: 800px) 500px, 800px\\" srcset=\\"/_ipx/s_200x300/image.png 200w, /_ipx/s_400x600/image.png 400w, /_ipx/s_500x750/image.png 500w, /_ipx/s_800x1200/image.png 800w, /_ipx/s_1000x1500/image.png 1000w, /_ipx/s_1600x2400/image.png 1600w\\">"')
   })
 
   it('encodes characters', () => {
@@ -122,7 +122,7 @@ describe('Renders simple image', () => {
       sizes: '200,500:500,900:900',
       src: '/汉字.png'
     })
-    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1800x1800/%E6%B1%89%E5%AD%97.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/s_200x200/%E6%B1%89%E5%AD%97.png 200w, /_ipx/s_400x400/%E6%B1%89%E5%AD%97.png 400w, /_ipx/s_500x500/%E6%B1%89%E5%AD%97.png 500w, /_ipx/s_900x900/%E6%B1%89%E5%AD%97.png 900w, /_ipx/s_1000x1000/%E6%B1%89%E5%AD%97.png 1000w, /_ipx/s_1800x1800/%E6%B1%89%E5%AD%97.png 1800w\\">"')
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1800x1800/%E6%B1%89%E5%AD%97.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/s_200x200/%E6%B1%89%E5%AD%97.png 200w, /_ipx/s_400x400/%E6%B1%89%E5%AD%97.png 400w, /_ipx/s_500x500/%E6%B1%89%E5%AD%97.png 500w, /_ipx/s_900x900/%E6%B1%89%E5%AD%97.png 900w, /_ipx/s_1000x1000/%E6%B1%89%E5%AD%97.png 1000w, /_ipx/s_1800x1800/%E6%B1%89%E5%AD%97.png 1800w\\">"')
   })
 
   it('correctly sets crop', () => {
@@ -132,7 +132,7 @@ describe('Renders simple image', () => {
       height: 2000,
       sizes: 'xs:100vw sm:100vw md:300px lg:350px xl:350px 2xl:350px'
     })
-    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1280x2560/image.png\\" width=\\"1000\\" height=\\"2000\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 320px) 100vw, (max-width: 640px) 100vw, (max-width: 768px) 300px, (max-width: 1024px) 350px, (max-width: 1280px) 350px, 350px\\" srcset=\\"/_ipx/s_300x600/image.png 300w, /_ipx/s_320x640/image.png 320w, /_ipx/s_350x700/image.png 350w, /_ipx/s_600x1200/image.png 600w, /_ipx/s_640x1280/image.png 640w, /_ipx/s_700x1400/image.png 700w, /_ipx/s_1280x2560/image.png 1280w\\">"')
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1280x2560/image.png\\" width=\\"1000\\" height=\\"2000\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 640px) 100vw, (max-width: 768px) 100vw, (max-width: 1024px) 300px, (max-width: 1280px) 350px, (max-width: 1536px) 350px, 350px\\" srcset=\\"/_ipx/s_300x600/image.png 300w, /_ipx/s_320x640/image.png 320w, /_ipx/s_350x700/image.png 350w, /_ipx/s_600x1200/image.png 600w, /_ipx/s_640x1280/image.png 640w, /_ipx/s_700x1400/image.png 700w, /_ipx/s_1280x2560/image.png 1280w\\">"')
   })
 
   it('without sizes, but densities', () => {
@@ -225,15 +225,15 @@ describe('Renders placeholder image', () => {
 
     let sizes = wrapper.find('img').element.getAttribute('sizes')
 
-    expect(sizes).toBe(null)
-    expect(placeholderImage.sizes).toBe('(max-width: 200px) 200px, (max-width: 500px) 500px, 900px')
+    expect(sizes).toMatchInlineSnapshot('null')
+    expect(placeholderImage.sizes).toMatchInlineSnapshot('"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px"')
 
     resolveImage()
     await nextTick()
 
     sizes = wrapper.find('img').element.getAttribute('sizes')
 
-    expect(sizes).toBe('(max-width: 200px) 200px, (max-width: 500px) 500px, 900px')
+    expect(sizes).toMatchInlineSnapshot('"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px"')
     expect(wrapper.emitted().load[0]).toStrictEqual([loadEvent])
   })
 })
@@ -263,9 +263,7 @@ describe('Renders image, applies module config', () => {
         sizes: '200,500:500,900:900'
       }
     })
-    expect(img.html()).toMatchInlineSnapshot(`
-      "<img src=\\"/_ipx/q_75&s_1800x1800/image.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/q_75&s_200x200/image.png 200w, /_ipx/q_75&s_400x400/image.png 400w, /_ipx/q_75&s_500x500/image.png 500w, /_ipx/q_75&s_900x900/image.png 900w, /_ipx/q_75&s_1000x1000/image.png 1000w, /_ipx/q_75&s_1800x1800/image.png 1800w\\">"
-    `)
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/q_75&s_1800x1800/image.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/q_75&s_200x200/image.png 200w, /_ipx/q_75&s_400x400/image.png 400w, /_ipx/q_75&s_500x500/image.png 500w, /_ipx/q_75&s_900x900/image.png 900w, /_ipx/q_75&s_1000x1000/image.png 1000w, /_ipx/q_75&s_1800x1800/image.png 1800w\\">"')
   })
 
   it('Module config .quality + props.quality => props.quality applies', () => {
@@ -285,9 +283,7 @@ describe('Renders image, applies module config', () => {
         quality: 90
       }
     })
-    expect(img.html()).toMatchInlineSnapshot(`
-      "<img src=\\"/_ipx/q_90&s_1800x1800/image.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/q_90&s_200x200/image.png 200w, /_ipx/q_90&s_400x400/image.png 400w, /_ipx/q_90&s_500x500/image.png 500w, /_ipx/q_90&s_900x900/image.png 900w, /_ipx/q_90&s_1000x1000/image.png 1000w, /_ipx/q_90&s_1800x1800/image.png 1800w\\">"
-    `)
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/q_90&s_1800x1800/image.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/q_90&s_200x200/image.png 200w, /_ipx/q_90&s_400x400/image.png 400w, /_ipx/q_90&s_500x500/image.png 500w, /_ipx/q_90&s_900x900/image.png 900w, /_ipx/q_90&s_1000x1000/image.png 1000w, /_ipx/q_90&s_1800x1800/image.png 1800w\\">"')
   })
 
   it('Without quality config => default image', () => {
@@ -305,9 +301,7 @@ describe('Renders image, applies module config', () => {
         sizes: '200,500:500,900:900'
       }
     })
-    expect(img.html()).toMatchInlineSnapshot(`
-      "<img src=\\"/_ipx/s_1800x1800/image.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/s_200x200/image.png 200w, /_ipx/s_400x400/image.png 400w, /_ipx/s_500x500/image.png 500w, /_ipx/s_900x900/image.png 900w, /_ipx/s_1000x1000/image.png 1000w, /_ipx/s_1800x1800/image.png 1800w\\">"
-    `)
+    expect(img.html()).toMatchInlineSnapshot('"<img src=\\"/_ipx/s_1800x1800/image.png\\" width=\\"200\\" height=\\"200\\" data-nuxt-img=\\"\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/s_200x200/image.png 200w, /_ipx/s_400x400/image.png 400w, /_ipx/s_500x500/image.png 500w, /_ipx/s_900x900/image.png 900w, /_ipx/s_1000x1000/image.png 1000w, /_ipx/s_1800x1800/image.png 1800w\\">"')
   })
 })
 

--- a/test/unit/picture.test.ts
+++ b/test/unit/picture.test.ts
@@ -50,7 +50,7 @@ describe('Renders simple image', () => {
   it('Matches snapshot', () => {
     expect(wrapper.html()).toMatchInlineSnapshot(`
       "<picture>
-        <source type=\\"image/webp\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&s_200x200/image.png 200w, /_ipx/f_webp&s_400x400/image.png 400w, /_ipx/f_webp&s_500x500/image.png 500w, /_ipx/f_webp&s_900x900/image.png 900w, /_ipx/f_webp&s_1000x1000/image.png 1000w, /_ipx/f_webp&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/image.png\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/image.png 200w, /_ipx/f_png&s_400x400/image.png 400w, /_ipx/f_png&s_500x500/image.png 500w, /_ipx/f_png&s_900x900/image.png 900w, /_ipx/f_png&s_1000x1000/image.png 1000w, /_ipx/f_png&s_1800x1800/image.png 1800w\\">
+        <source type=\\"image/webp\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&s_200x200/image.png 200w, /_ipx/f_webp&s_400x400/image.png 400w, /_ipx/f_webp&s_500x500/image.png 500w, /_ipx/f_webp&s_900x900/image.png 900w, /_ipx/f_webp&s_1000x1000/image.png 1000w, /_ipx/f_webp&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/image.png\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/image.png 200w, /_ipx/f_png&s_400x400/image.png 400w, /_ipx/f_png&s_500x500/image.png 500w, /_ipx/f_png&s_900x900/image.png 900w, /_ipx/f_png&s_1000x1000/image.png 1000w, /_ipx/f_png&s_1800x1800/image.png 1800w\\">
       </picture>"
     `)
   })
@@ -123,7 +123,7 @@ describe('Renders simple image', () => {
 
   it('sizes', () => {
     const sizes = wrapper.find('source').element.getAttribute('sizes')
-    expect(sizes).toBe('(max-width: 200px) 200px, (max-width: 500px) 500px, 900px')
+    expect(sizes).toMatchInlineSnapshot('"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px"')
   })
 
   it('renders src when svg is passed', () => {
@@ -147,7 +147,7 @@ describe('Renders simple image', () => {
     })
     expect(img.html()).toMatchInlineSnapshot(`
       "<picture>
-        <source type=\\"image/webp\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&s_200x200/%E6%B1%89%E5%AD%97.png 200w, /_ipx/f_webp&s_400x400/%E6%B1%89%E5%AD%97.png 400w, /_ipx/f_webp&s_500x500/%E6%B1%89%E5%AD%97.png 500w, /_ipx/f_webp&s_900x900/%E6%B1%89%E5%AD%97.png 900w, /_ipx/f_webp&s_1000x1000/%E6%B1%89%E5%AD%97.png 1000w, /_ipx/f_webp&s_1800x1800/%E6%B1%89%E5%AD%97.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/%E6%B1%89%E5%AD%97.png\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/%E6%B1%89%E5%AD%97.png 200w, /_ipx/f_png&s_400x400/%E6%B1%89%E5%AD%97.png 400w, /_ipx/f_png&s_500x500/%E6%B1%89%E5%AD%97.png 500w, /_ipx/f_png&s_900x900/%E6%B1%89%E5%AD%97.png 900w, /_ipx/f_png&s_1000x1000/%E6%B1%89%E5%AD%97.png 1000w, /_ipx/f_png&s_1800x1800/%E6%B1%89%E5%AD%97.png 1800w\\">
+        <source type=\\"image/webp\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&s_200x200/%E6%B1%89%E5%AD%97.png 200w, /_ipx/f_webp&s_400x400/%E6%B1%89%E5%AD%97.png 400w, /_ipx/f_webp&s_500x500/%E6%B1%89%E5%AD%97.png 500w, /_ipx/f_webp&s_900x900/%E6%B1%89%E5%AD%97.png 900w, /_ipx/f_webp&s_1000x1000/%E6%B1%89%E5%AD%97.png 1000w, /_ipx/f_webp&s_1800x1800/%E6%B1%89%E5%AD%97.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/%E6%B1%89%E5%AD%97.png\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/%E6%B1%89%E5%AD%97.png 200w, /_ipx/f_png&s_400x400/%E6%B1%89%E5%AD%97.png 400w, /_ipx/f_png&s_500x500/%E6%B1%89%E5%AD%97.png 500w, /_ipx/f_png&s_900x900/%E6%B1%89%E5%AD%97.png 900w, /_ipx/f_png&s_1000x1000/%E6%B1%89%E5%AD%97.png 1000w, /_ipx/f_png&s_1800x1800/%E6%B1%89%E5%AD%97.png 1800w\\">
       </picture>"
     `)
   })
@@ -183,7 +183,7 @@ describe('Renders image, applies module config', () => {
     })
     expect(picture.html()).toMatchInlineSnapshot(`
       "<picture>
-        <source type=\\"image/webp\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&s_200x200/image.png 200w, /_ipx/f_webp&s_400x400/image.png 400w, /_ipx/f_webp&s_500x500/image.png 500w, /_ipx/f_webp&s_900x900/image.png 900w, /_ipx/f_webp&s_1000x1000/image.png 1000w, /_ipx/f_webp&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/image.png\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/image.png 200w, /_ipx/f_png&s_400x400/image.png 400w, /_ipx/f_png&s_500x500/image.png 500w, /_ipx/f_png&s_900x900/image.png 900w, /_ipx/f_png&s_1000x1000/image.png 1000w, /_ipx/f_png&s_1800x1800/image.png 1800w\\">
+        <source type=\\"image/webp\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&s_200x200/image.png 200w, /_ipx/f_webp&s_400x400/image.png 400w, /_ipx/f_webp&s_500x500/image.png 500w, /_ipx/f_webp&s_900x900/image.png 900w, /_ipx/f_webp&s_1000x1000/image.png 1000w, /_ipx/f_webp&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/image.png\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/image.png 200w, /_ipx/f_png&s_400x400/image.png 400w, /_ipx/f_png&s_500x500/image.png 500w, /_ipx/f_png&s_900x900/image.png 900w, /_ipx/f_png&s_1000x1000/image.png 1000w, /_ipx/f_png&s_1800x1800/image.png 1800w\\">
       </picture>"
     `)
   })
@@ -206,7 +206,7 @@ describe('Renders image, applies module config', () => {
     })
     expect(picture.html()).toMatchInlineSnapshot(`
       "<picture>
-  <source type=\\"image/avif\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_avif&s_200x200/image.png 200w, /_ipx/f_avif&s_400x400/image.png 400w, /_ipx/f_avif&s_500x500/image.png 500w, /_ipx/f_avif&s_900x900/image.png 900w, /_ipx/f_avif&s_1000x1000/image.png 1000w, /_ipx/f_avif&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/image.png\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/image.png 200w, /_ipx/f_png&s_400x400/image.png 400w, /_ipx/f_png&s_500x500/image.png 500w, /_ipx/f_png&s_900x900/image.png 900w, /_ipx/f_png&s_1000x1000/image.png 1000w, /_ipx/f_png&s_1800x1800/image.png 1800w\\">
+        <source type=\\"image/avif\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_avif&s_200x200/image.png 200w, /_ipx/f_avif&s_400x400/image.png 400w, /_ipx/f_avif&s_500x500/image.png 500w, /_ipx/f_avif&s_900x900/image.png 900w, /_ipx/f_avif&s_1000x1000/image.png 1000w, /_ipx/f_avif&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/image.png\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/image.png 200w, /_ipx/f_png&s_400x400/image.png 400w, /_ipx/f_png&s_500x500/image.png 500w, /_ipx/f_png&s_900x900/image.png 900w, /_ipx/f_png&s_1000x1000/image.png 1000w, /_ipx/f_png&s_1800x1800/image.png 1800w\\">
       </picture>"
     `)
   })
@@ -229,8 +229,8 @@ describe('Renders image, applies module config', () => {
     })
     expect(picture.html()).toMatchInlineSnapshot(`
       "<picture>
-        <source type=\\"image/avif\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_avif&s_200x200/image.png 200w, /_ipx/f_avif&s_400x400/image.png 400w, /_ipx/f_avif&s_500x500/image.png 500w, /_ipx/f_avif&s_900x900/image.png 900w, /_ipx/f_avif&s_1000x1000/image.png 1000w, /_ipx/f_avif&s_1800x1800/image.png 1800w\\">
-        <source type=\\"image/webp\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&s_200x200/image.png 200w, /_ipx/f_webp&s_400x400/image.png 400w, /_ipx/f_webp&s_500x500/image.png 500w, /_ipx/f_webp&s_900x900/image.png 900w, /_ipx/f_webp&s_1000x1000/image.png 1000w, /_ipx/f_webp&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/image.png\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/image.png 200w, /_ipx/f_png&s_400x400/image.png 400w, /_ipx/f_png&s_500x500/image.png 500w, /_ipx/f_png&s_900x900/image.png 900w, /_ipx/f_png&s_1000x1000/image.png 1000w, /_ipx/f_png&s_1800x1800/image.png 1800w\\">
+        <source type=\\"image/avif\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_avif&s_200x200/image.png 200w, /_ipx/f_avif&s_400x400/image.png 400w, /_ipx/f_avif&s_500x500/image.png 500w, /_ipx/f_avif&s_900x900/image.png 900w, /_ipx/f_avif&s_1000x1000/image.png 1000w, /_ipx/f_avif&s_1800x1800/image.png 1800w\\">
+        <source type=\\"image/webp\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&s_200x200/image.png 200w, /_ipx/f_webp&s_400x400/image.png 400w, /_ipx/f_webp&s_500x500/image.png 500w, /_ipx/f_webp&s_900x900/image.png 900w, /_ipx/f_webp&s_1000x1000/image.png 1000w, /_ipx/f_webp&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/image.png\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/image.png 200w, /_ipx/f_png&s_400x400/image.png 400w, /_ipx/f_png&s_500x500/image.png 500w, /_ipx/f_png&s_900x900/image.png 900w, /_ipx/f_png&s_1000x1000/image.png 1000w, /_ipx/f_png&s_1800x1800/image.png 1800w\\">
       </picture>"
     `)
   })
@@ -254,7 +254,7 @@ describe('Renders image, applies module config', () => {
     })
     expect(picture.html()).toMatchInlineSnapshot(`
       "<picture>
-  <source type=\\"image/avif\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_avif&s_200x200/image.png 200w, /_ipx/f_avif&s_400x400/image.png 400w, /_ipx/f_avif&s_500x500/image.png 500w, /_ipx/f_avif&s_900x900/image.png 900w, /_ipx/f_avif&s_1000x1000/image.png 1000w, /_ipx/f_avif&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/image.png\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/image.png 200w, /_ipx/f_png&s_400x400/image.png 400w, /_ipx/f_png&s_500x500/image.png 500w, /_ipx/f_png&s_900x900/image.png 900w, /_ipx/f_png&s_1000x1000/image.png 1000w, /_ipx/f_png&s_1800x1800/image.png 1800w\\">
+        <source type=\\"image/avif\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_avif&s_200x200/image.png 200w, /_ipx/f_avif&s_400x400/image.png 400w, /_ipx/f_avif&s_500x500/image.png 500w, /_ipx/f_avif&s_900x900/image.png 900w, /_ipx/f_avif&s_1000x1000/image.png 1000w, /_ipx/f_avif&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&s_1800x1800/image.png\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_png&s_200x200/image.png 200w, /_ipx/f_png&s_400x400/image.png 400w, /_ipx/f_png&s_500x500/image.png 500w, /_ipx/f_png&s_900x900/image.png 900w, /_ipx/f_png&s_1000x1000/image.png 1000w, /_ipx/f_png&s_1800x1800/image.png 1800w\\">
       </picture>"
     `)
   })
@@ -297,7 +297,7 @@ describe('Renders image, applies module config', () => {
 
     expect(picture.html()).toMatchInlineSnapshot(`
       "<picture>
-        <source type=\\"image/webp\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&q_75&s_200x200/image.png 200w, /_ipx/f_webp&q_75&s_400x400/image.png 400w, /_ipx/f_webp&q_75&s_500x500/image.png 500w, /_ipx/f_webp&q_75&s_900x900/image.png 900w, /_ipx/f_webp&q_75&s_1000x1000/image.png 1000w, /_ipx/f_webp&q_75&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&q_75&s_1800x1800/image.png\\" sizes=\\"(max-width: 200px) 200px, (max-width: 500px) 500px, 900px\\" srcset=\\"/_ipx/f_png&q_75&s_200x200/image.png 200w, /_ipx/f_png&q_75&s_400x400/image.png 400w, /_ipx/f_png&q_75&s_500x500/image.png 500w, /_ipx/f_png&q_75&s_900x900/image.png 900w, /_ipx/f_png&q_75&s_1000x1000/image.png 1000w, /_ipx/f_png&q_75&s_1800x1800/image.png 1800w\\">
+        <source type=\\"image/webp\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_webp&q_75&s_200x200/image.png 200w, /_ipx/f_webp&q_75&s_400x400/image.png 400w, /_ipx/f_webp&q_75&s_500x500/image.png 500w, /_ipx/f_webp&q_75&s_900x900/image.png 900w, /_ipx/f_webp&q_75&s_1000x1000/image.png 1000w, /_ipx/f_webp&q_75&s_1800x1800/image.png 1800w\\"><img width=\\"200\\" height=\\"200\\" data-nuxt-pic=\\"\\" src=\\"/_ipx/f_png&q_75&s_1800x1800/image.png\\" sizes=\\"(max-width: 500px) 200px, (max-width: 900px) 500px, 900px\\" srcset=\\"/_ipx/f_png&q_75&s_200x200/image.png 200w, /_ipx/f_png&q_75&s_400x400/image.png 400w, /_ipx/f_png&q_75&s_500x500/image.png 500w, /_ipx/f_png&q_75&s_900x900/image.png 900w, /_ipx/f_png&q_75&s_1000x1000/image.png 1000w, /_ipx/f_png&q_75&s_1800x1800/image.png 1800w\\">
       </picture>"
     `)
   })


### PR DESCRIPTION
resolves https://github.com/nuxt/image/issues/645

This aims to enable responsive sizing by default. It has two breaking changes:

1. sizes without an explicit screen width (e.g. `sizes="100vw"`) are interpreted as a _responsive_ minimum size, e.g. `1px:100vw`.
2. Sizes are output from that screen-size _up_ rather than that screen-size _down_, so `sizes="md:100px lg:200px"` means that the image is displayed at `100px` by default. And at `lg` and above, at `200px`. (Previously, this meant that it was displayed at 100px only up to `md`, and then displayed at `200px` for all sizes above that.)

As these are both significant changes from previous behaviour, special care is requested in evaluating the API and DX.