### PR TITLE
Add support to preload responsive images on V0

### DIFF
--- a/src/runtime/components/nuxt-img.vue
+++ b/src/runtime/components/nuxt-img.vue
@@ -24,12 +24,19 @@ export default defineComponent({
   },
   head () {
     if (this.preload === true) {
+      const isResponsive = Object.values(this.nSizes).every(v => v)
       return {
         link: [
           {
             rel: 'preload',
             as: 'image',
-            href: this.nSrc
+            ...(!isResponsive
+            ? { href: this.nSrc }
+            : {
+                href: this.nSrc.src,
+                imagesizes: this.nSrc.sizes,
+                imagesrcset: this.nSrc.srcset
+              })
           }
         ]
       }

--- a/src/runtime/components/nuxt-img.vue
+++ b/src/runtime/components/nuxt-img.vue
@@ -33,9 +33,9 @@ export default defineComponent({
             ...(!isResponsive
             ? { href: this.nSrc }
             : {
-                href: this.nSrc.src,
-                imagesizes: this.nSrc.sizes,
-                imagesrcset: this.nSrc.srcset
+                href: this.nSizes.src,
+                imagesizes: this.nSizes.sizes,
+                imagesrcset: this.nSizes.srcset
               })
           }
         ]


### PR DESCRIPTION
Adds support to preload responsive images on V0

resolves #612 

Logic copied from `main` version:
https://github.com/nuxt/image/blob/36285464fc10b4d6e7ad8bf166d89e6d09ff88df/src/runtime/components/nuxt-img.ts#L82