### PR TITLE
Fix formatting in `1.nuxt-img.md`

### DIFF
--- a/docs/content/2.usage/1.nuxt-img.md
+++ b/docs/content/2.usage/1.nuxt-img.md
@@ -284,8 +284,6 @@ const nonce = useNonce()
 </script>
 ```
 
-```html
-
 ## Events
 
 Native events emitted by the `<img>` element contained by `<NuxtImg>` and `<NuxtPicture>` components are re-emitted and can be listened to.


### PR DESCRIPTION
This PR addresses the incorrect format of the Events section in the `NuxtImg` component docs: https://image.nuxt.com/usage/nuxt-img#nonce