### PR TITLE
fix(cloudimage): skip cdn when `src` path is provided with protocol

### DIFF
--- a/playground/providers.ts
+++ b/playground/providers.ts
@@ -137,6 +137,15 @@ export const providers: Provider[] = [
     name: 'cloudimage',
     samples: [
       {
+        src: 'https://2412819702-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FlIgyYELwJG6odLEyCM6i%2Fuploads%2FAHcbuKRYbIlBWO4cJ88b%2Fimage.png?alt=media&token=62ff753d-83eb-4e3f-932c-96eb72d455f1',
+        width: 400,
+        height: 250,
+        densities: 'x1 x2',
+        fit: 'contain',
+        quality: 65,
+        format: 'webp'
+      },
+      {
         src: 'bag.jpg',
         width: 500,
         height: 500,

--- a/src/runtime/providers/cloudimage.ts
+++ b/src/runtime/providers/cloudimage.ts
@@ -55,6 +55,12 @@ export const getImage: ProviderGetImage = (src, {
     cdnURL = `https://${token}.cloudimg.io/${apiVersion}`
   }
 
+  if (src.startsWith('http')) {
+    return {
+      url: joinURL(src) + (operations ? ('?' + operations) : '')
+    }
+  }
+
   return {
     url: joinURL(cdnURL, baseURL, src) + (operations ? ('?' + operations) : '')
   }

--- a/src/runtime/providers/cloudimage.ts
+++ b/src/runtime/providers/cloudimage.ts
@@ -1,4 +1,4 @@
-import { joinURL } from 'ufo'
+import { joinURL, hasProtocol } from 'ufo'
 import type { ProviderGetImage } from '../../types'
 import { createOperationsGenerator } from '#image'
 
@@ -30,6 +30,7 @@ export const getImage: ProviderGetImage = (src, {
   cdnURL = ''
 } = {}) => {
   const operations = operationsGenerator(modifiers)
+  const query = (operations ? ('?' + operations) : '')
 
   if (process.dev) {
     const warning = []
@@ -46,7 +47,7 @@ export const getImage: ProviderGetImage = (src, {
       // eslint-disable-next-line no-console
       console.warn(`[cloudimage] ${warning.join(', ')} is required to build image URL`)
       return {
-        url: joinURL('<token>', '<baseURL>', src) + (operations ? ('?' + operations) : '')
+        url: joinURL('<token>', '<baseURL>', src) + query
       }
     }
   }
@@ -55,13 +56,13 @@ export const getImage: ProviderGetImage = (src, {
     cdnURL = `https://${token}.cloudimg.io/${apiVersion}`
   }
 
-  if (src.startsWith('http')) {
+  if (hasProtocol(src)) {
     return {
-      url: joinURL(src) + (operations ? ('?' + operations) : '')
+      url: joinURL(src) + query
     }
   }
 
   return {
-    url: joinURL(cdnURL, baseURL, src) + (operations ? ('?' + operations) : '')
+    url: joinURL(cdnURL, baseURL, src) + query
   }
 }

--- a/test/e2e/__snapshots__/no-ssr.test.ts.snap
+++ b/test/e2e/__snapshots__/no-ssr.test.ts.snap
@@ -14,6 +14,7 @@ exports[`browser (ssr: false) > cloudflare should render images 2`] = `
 
 exports[`browser (ssr: false) > cloudimage should render images 1`] = `
 [
+  "https://2412819702-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FlIgyYELwJG6odLEyCM6i%2Fuploads%2FAHcbuKRYbIlBWO4cJ88b%2Fimage.png?alt=media&token=62ff753d-83eb-4e3f-932c-96eb72d455f1?width=400&height=250&force_format=webp&q=65&func=fit",
   "https://demo.cloudimg.io/v7/sample.li/bag.jpg?width=500&height=500&func=fit",
   "https://demo.cloudimg.io/v7/sample.li/boat.jpg?width=800&height=800&q=75&func=crop",
   "https://demo.cloudimg.io/v7/sample.li/img.jpg?width=300&height=300&force_format=webp&func=cover",
@@ -22,6 +23,7 @@ exports[`browser (ssr: false) > cloudimage should render images 1`] = `
 
 exports[`browser (ssr: false) > cloudimage should render images 2`] = `
 [
+  "https://2412819702-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FlIgyYELwJG6odLEyCM6i%2Fuploads%2FAHcbuKRYbIlBWO4cJ88b%2Fimage.png?alt=media&token=62ff753d-83eb-4e3f-932c-96eb72d455f1?width=400&height=250&force_format=webp&q=65&func=fit",
   "https://demo.cloudimg.io/v7/sample.li/bag.jpg?width=500&height=500&func=fit",
   "https://demo.cloudimg.io/v7/sample.li/boat.jpg?width=800&height=800&q=75&func=crop",
   "https://demo.cloudimg.io/v7/sample.li/img.jpg?width=300&height=300&force_format=webp&func=cover",

--- a/test/e2e/__snapshots__/ssr.test.ts.snap
+++ b/test/e2e/__snapshots__/ssr.test.ts.snap
@@ -14,6 +14,7 @@ exports[`browser (ssr: true) > cloudflare should render images 2`] = `
 
 exports[`browser (ssr: true) > cloudimage should render images 1`] = `
 [
+  "https://2412819702-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FlIgyYELwJG6odLEyCM6i%2Fuploads%2FAHcbuKRYbIlBWO4cJ88b%2Fimage.png?alt=media&token=62ff753d-83eb-4e3f-932c-96eb72d455f1?width=400&height=250&force_format=webp&q=65&func=fit",
   "https://demo.cloudimg.io/v7/sample.li/bag.jpg?width=500&height=500&func=fit",
   "https://demo.cloudimg.io/v7/sample.li/boat.jpg?width=800&height=800&q=75&func=crop",
   "https://demo.cloudimg.io/v7/sample.li/img.jpg?width=300&height=300&force_format=webp&func=cover",
@@ -22,6 +23,7 @@ exports[`browser (ssr: true) > cloudimage should render images 1`] = `
 
 exports[`browser (ssr: true) > cloudimage should render images 2`] = `
 [
+  "https://2412819702-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FlIgyYELwJG6odLEyCM6i%2Fuploads%2FAHcbuKRYbIlBWO4cJ88b%2Fimage.png?alt=media&token=62ff753d-83eb-4e3f-932c-96eb72d455f1?width=400&height=250&force_format=webp&q=65&func=fit",
   "https://demo.cloudimg.io/v7/sample.li/bag.jpg?width=500&height=500&func=fit",
   "https://demo.cloudimg.io/v7/sample.li/boat.jpg?width=800&height=800&q=75&func=crop",
   "https://demo.cloudimg.io/v7/sample.li/img.jpg?width=300&height=300&force_format=webp&func=cover",


### PR DESCRIPTION
**Problem**
* **Cloudimage**: Images starting with `HTTP` should not be prefixed with `Base Url`

**issues**
* https://github.com/nuxt/image/issues/1026

**Solution**
* Add condition if src `startwith http` return src with generate query parameters

**Before:**
* `https://token.cloudimg.io/__path__/https://2412819702-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FlIgyYELwJG6odLEyCM6i%2Fuploads%2FAHcbuKRYbIlBWO4cJ88b%2Fimage.png?alt=media&token=62ff753d-83eb-4e3f-932c-96eb72d455f1?height=100&width=100&q=65&func=crop`

**After:**
* `https://2412819702-files.gitbook.io/~/files/v0/b/gitbook-x-prod.appspot.com/o/spaces%2FlIgyYELwJG6odLEyCM6i%2Fuploads%2FAHcbuKRYbIlBWO4cJ88b%2Fimage.png?alt=media&token=62ff753d-83eb-4e3f-932c-96eb72d455f1?height=100&width=100&q=65&func=crop`

**Remaining**
* I have tried to do that for all providers, but the provider manages the logic of the URL, so I can't test this and can't do that for all providers. Do you have any idea?