### PR TITLE
docs: add title to provider links

### DIFF
--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -89,7 +89,7 @@ const providers = ['cloudflare', 'cloudimage', 'cloudinary', 'directus', 'edgio'
       </UButton>
     </template>
     <div class="grid grid-cols-5 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-6 gap-4 sm:gap-5 lg:gap-6">
-      <NuxtLink v-for="(provider, index) in providers" :key="index" :to="`/providers/${provider}`" class="block lg:hover:scale-110 transition">
+      <NuxtLink v-for="(provider, index) in providers" :key="index" :to="`/providers/${provider}`" :title="provider" class="block lg:hover:scale-110 transition">
         <!-- <NuxtImg :placeholder="img(`/providers/${provider}.svg`, { h: 10, f: 'png', blur: 2, q: 50 })" :src="`/providers/${provider}.svg`" :alt="provider" width="64" height="64" class="w-12 h-12 sm:w-16 sm:h-16 rounded-xl" loading="lazy" /> -->
         <NuxtImg :src="`/providers/${provider}.svg`" :alt="provider" width="64" height="64" class="w-12 h-12 sm:w-16 sm:h-16 rounded-xl" loading="lazy" />
       </NuxtLink>


### PR DESCRIPTION
## 📚Description

Just a small update to add the native browser tooltip for the providers in the home page. This way people who don't recognize a particular logo can just hover over the icons and see the provider's name. 

![image](https://github.com/nuxt/image/assets/31937175/1b46bf59-6755-4686-8097-ee6cf3326182)
