### PR TITLE
fix(ipx)!: pass all options

### DIFF
--- a/playground/nuxt.config.ts
+++ b/playground/nuxt.config.ts
@@ -13,6 +13,14 @@ export default defineNuxtConfig({
       750: 750
     },
     none: {},
+    ipx: {
+      sharpOptions: {
+        animated: true
+      },
+      maxAge: 50,
+      fs: { maxAge: 51 },
+      http: { maxAge: 52 }
+    },
     alias: {
       unsplash: 'https://images.unsplash.com', // ipx
       blog: '/remote/nuxt-org/blog' // cloudinary

--- a/src/module.ts
+++ b/src/module.ts
@@ -10,7 +10,6 @@ export interface ModuleOptions extends ImageProviders {
   presets: { [name: string]: ImageOptions }
   dir: string
   domains: string[]
-  sharp: any
   alias: Record<string, string>
   screens: CreateImageOptions['screens']
   providers: { [name: string]: InputProvider | any } & ImageProviders
@@ -139,7 +138,9 @@ ${providers.map(p => `  ['${p.name}']: { provider: ${p.importName}, defaults: ${
         imageOptions.provider = options.provider = resolvedProvider
         options[resolvedProvider] = options[resolvedProvider] || {}
 
-        const p = await resolveProvider(nuxt, resolvedProvider, options[resolvedProvider])
+        const p = await resolveProvider(nuxt, resolvedProvider, {
+          options: options[resolvedProvider]
+        })
         if (!providers.some(p => p.name === resolvedProvider)) {
           providers.push(p)
         }

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -1,6 +1,6 @@
-import type { IPXOptions } from 'ipx'
 import type { Nuxt } from '@nuxt/schema'
 import type { ModuleOptions } from '../module'
+import { IPXRuntimeConfig } from '../ipx'
 import type { ImageModifiers } from './image'
 
 // eslint-disable-next-line no-use-before-define
@@ -84,8 +84,8 @@ export interface ImageProviders {
   strapi?: any,
   imageengine?: any,
   uploadcare?: Partial<UploadcareOptions>,
-  ipx?: Partial<IPXOptions>
-  static?: Partial<IPXOptions>
+  ipx?: Partial<IPXRuntimeConfig>
+  static?: Partial<IPXRuntimeConfig>
 }
 
 export interface ImageModuleProvider {


### PR DESCRIPTION
Rework of #976

Pass all IPX provider options correctly.

Slight breaking change before 1.0.0: `sharp` has been moved under `ipx.sharpOptions` to allow future changes for IPX decoupling from image module top-level options.