### PR TITLE
docs: fix typo

### DIFF
--- a/docs/content/1.get-started/4.contributing.md
+++ b/docs/content/1.get-started/4.contributing.md
@@ -24,6 +24,6 @@ It is highly recommended to read [Nuxt contribution guide](https://nuxt.com/docs
 
 ### Documentation
 
-- Use `pnpm dev:docs` to start the [documentation](https://github.com/nuxt/image/tree/main/docs) in development mode.
+- Use `pnpm docs:dev` to start the [documentation](https://github.com/nuxt/image/tree/main/docs) in development mode.
 - Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
 - Update the content of the documentation in the [docs/content/](https://github.com/nuxt/image/tree/main/docs/content) directory.


### PR DESCRIPTION
docs: fix typo `pnpm dev:docs` => `pnpm docs:dev` .