### PR TITLE
docs: explain fall back to larger size on amplify + vercel

### DIFF
--- a/docs/content/3.providers/aws-amplify.md
+++ b/docs/content/3.providers/aws-amplify.md
@@ -36,7 +36,7 @@ export default {
 
 Specify any custom `width` property you use in `<NuxtImg>`, `<NuxtPicture>` and `$img`.
 
-If a width is not defined, image will fallback to closest possible width.
+If a width is not defined, image will fallback to the next bigger width.
 
 **Example:**
 

--- a/docs/content/3.providers/vercel.md
+++ b/docs/content/3.providers/vercel.md
@@ -32,7 +32,7 @@ export default {
 
 Specify any custom `width` property you use in `<NuxtImg>`, `<NuxtPicture>` and `$img`.
 
-If a width is not defined, image will fallback to closest possible width.
+If a width is not defined, image will fallback to the next bigger width.
 
 **Example:**
 


### PR DESCRIPTION
The documentation states that the image provider will fallback to the >nearest< image width when a image width was not defined in the screens option. This is not the actual behavior. Actually, the next bigger screen width is return. I've tried to reflect this with this change.