### PR TITLE
ci: fix release job conditional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Playwright
         # does not need to explicitly set chromium after https://github.com/microsoft/playwright/issues/14862 is solved
         run: pnpm playwright-core install chromium
-        
+
       - run: pnpm dev:prepare
       - run: pnpm lint
       - run: pnpm test -- --coverage
@@ -54,7 +54,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: ci
-    if: github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip-release]')
+    if: github.event_name == 'push' && !startsWith(github.event.head_commit.message, '[skip-release]')
     permissions:
       id-token: write
     steps:
@@ -70,7 +70,7 @@ jobs:
       - name: Release Edge
         if: |
           github.event_name == 'push' &&
-          !contains(github.event.head_commit.message, '[skip-release]')
+          !startsWith(github.event.head_commit.message, '[skip-release]')
         run: ./scripts/release-edge.sh
         env:
           NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}


### PR DESCRIPTION
This fixes the release job conditional so it only checks the merge commit title and not the squashed commits in the commit body. This could incorrectly skip/prevent a release if the body contains one of the checked keywords.

I'm opening this PR in multiple repositories, in this case since it only checks for `'[skip-release]'` so it's much less likely to be triggered by squashed commit messages. Still opening this PR for consistency 😅 

