### PR TITLE
docs: added deprecated message Netlify Large Media

### DIFF
--- a/docs/content/3.providers/netlify.md
+++ b/docs/content/3.providers/netlify.md
@@ -8,7 +8,9 @@ links:
     size: xs
 ---
 
-> ❗ Netlify’s Large Media service is [deprecated](https://answers.netlify.com/t/large-media-feature-deprecated-but-not-removed/100804). If this feature is already enabled, Large Media will continue to work on these sites as usual. New Large Media configuration is not recommended.
+::callout{color="amber" icon="i-ph-warning-duotone"}
+Netlify’s Large Media service is [deprecated](https://answers.netlify.com/t/large-media-feature-deprecated-but-not-removed/100804). If this feature is already enabled, Large Media will continue to work on these sites as usual. New Large Media configuration is not recommended.
+::
 
 Netlify offers dynamic image transformation for all JPEG, PNG, and GIF files you have set to be tracked with [Netlify Large Media](https://docs.netlify.com/large-media/overview/).
 

--- a/docs/content/3.providers/netlify.md
+++ b/docs/content/3.providers/netlify.md
@@ -8,6 +8,9 @@ links:
     size: xs
 ---
 
+> ❗ Deprecated
+> Netlify’s Large Media service is [deprecated](https://answers.netlify.com/t/large-media-feature-deprecated-but-not-removed/100804). If this feature is already enabled, Large Media will continue to work on these sites as usual. New Large Media configuration is not recommended.
+
 Netlify offers dynamic image transformation for all JPEG, PNG, and GIF files you have set to be tracked with [Netlify Large Media](https://docs.netlify.com/large-media/overview/).
 
 ::callout

--- a/docs/content/3.providers/netlify.md
+++ b/docs/content/3.providers/netlify.md
@@ -8,8 +8,7 @@ links:
     size: xs
 ---
 
-> ❗ Deprecated
-> Netlify’s Large Media service is [deprecated](https://answers.netlify.com/t/large-media-feature-deprecated-but-not-removed/100804). If this feature is already enabled, Large Media will continue to work on these sites as usual. New Large Media configuration is not recommended.
+> ❗ Netlify’s Large Media service is [deprecated](https://answers.netlify.com/t/large-media-feature-deprecated-but-not-removed/100804). If this feature is already enabled, Large Media will continue to work on these sites as usual. New Large Media configuration is not recommended.
 
 Netlify offers dynamic image transformation for all JPEG, PNG, and GIF files you have set to be tracked with [Netlify Large Media](https://docs.netlify.com/large-media/overview/).
 


### PR DESCRIPTION
**Just a minor thing!**
Netlify Large Media is deprecated. I added a small inline warning at the top of the documentation with some remarks from the official documentation. I linked to the official forum for a more in depth explanation.

I was wondering if this should also be mentioned in the title?
You could also argue that 'Netlify' should be hidden from the 'providers' navigation?