### PR TITLE
docs: add bun installation command

### DIFF
--- a/docs/content/1.get-started/1.installation.md
+++ b/docs/content/1.get-started/1.installation.md
@@ -19,6 +19,9 @@ yarn add @nuxt/image
 ```bash [npm]
 npm install @nuxt/image
 ```
+```bash [bun]
+bun add @nuxt/image
+```
 ::
 
 Add it to `modules` in your `nuxt.config`:


### PR DESCRIPTION
There was no installation command for Bun. In Nuxt documentation there are commands for bun so I think it would be good for consistency to add it there too