### PR TITLE
fix: use ipx for static builds instead of auto detect

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -131,10 +131,10 @@ ${providers.map(p => `  ['${p.name}']: { provider: ${p.importName}, defaults: ${
     })
 
     nuxt.hook('nitro:init', async (nitro) => {
-      if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic' || _detectedProvider.auto) {
+      if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic' || _detectedProvider?.auto) {
         const resolvedProvider = nitro.options.static || options.provider === 'ipxStatic'
           ? 'ipxStatic'
-          : nitro.options.node ? 'ipx' : 'none'
+          : _detectedProvider?.provider || (nitro.options.node ? 'ipx' : 'none')
 
         imageOptions.provider = options.provider = resolvedProvider
         options[resolvedProvider] = options[resolvedProvider] || {}

--- a/src/module.ts
+++ b/src/module.ts
@@ -66,10 +66,11 @@ export default defineNuxtModule<ModuleOptions>({
     // Normalize alias to start with leading slash
     options.alias = Object.fromEntries(Object.entries(options.alias).map(e => [withLeadingSlash(e[0]), e[1]]))
 
-    options.provider = detectProvider(options.provider)!
+    const _detectedProvider = detectProvider(options.provider)!
     if (options.provider) {
       options[options.provider] = options[options.provider] || {}
     }
+    options.provider = _detectedProvider?.provider
     options.densities = options.densities || []
 
     const imageOptions: Omit<CreateImageOptions, 'providers' | 'nuxt'> = pick(options, [
@@ -130,7 +131,7 @@ ${providers.map(p => `  ['${p.name}']: { provider: ${p.importName}, defaults: ${
     })
 
     nuxt.hook('nitro:init', async (nitro) => {
-      if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic') {
+      if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic' || _detectedProvider.auto) {
         const resolvedProvider = nitro.options.static || options.provider === 'ipxStatic'
           ? 'ipxStatic'
           : nitro.options.node ? 'ipx' : 'none'

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -139,16 +139,24 @@ const autodetectableProviders: Partial<Record<ProviderName, ImageProviderName>> 
   aws_amplify: 'awsAmplify'
 }
 
-export function detectProvider (userInput: string = '') {
+export function detectProvider (userInput: string = ''): undefined | { provider: string; auto: boolean } {
   if (process.env.NUXT_IMAGE_PROVIDER) {
-    return process.env.NUXT_IMAGE_PROVIDER
+    return {
+      provider: process.env.NUXT_IMAGE_PROVIDER,
+      auto: false
+    }
   }
-
   if (userInput && userInput !== 'auto') {
-    return userInput
+    return {
+      provider: userInput,
+      auto: false
+    }
   }
-
-  if (provider in autodetectableProviders) {
-    return autodetectableProviders[provider]
+  const autoDetected = autodetectableProviders[provider]
+  if (autoDetected) {
+    return {
+      provider: autoDetected,
+      auto: true
+    }
   }
 }


### PR DESCRIPTION
Context: We discovered it with @Atinux investigating broken nuxt UI docs since it was using vertical image optimization and not picked from.. Another story probably to solve for another day...

---

When building Nuxt in static mode (`nuxt generate`) we assume everything is at build-time. Auto detected providers (vercel, amplify) only benefit for production deploys with a server running where as for a static deploy, we can save (dynamic optimization) costs and reduce issue surface by optimizing at build time.

This PR improves `detectProvider` internal utility to preserve auto-detected status and later use in nitro hook to switch back to ipx-static if needed (so user input is still respected)