### PR TITLE
feat(imagekit): Added `effectShadow` and `effectGradient` modifiers.

### DIFF
--- a/docs/content/3.providers/imagekit.md
+++ b/docs/content/3.providers/imagekit.md
@@ -74,6 +74,31 @@ Turn your image to a grayscale version using the `effectGray` modifier.
 />
 ```
 
+### `effectShadow`
+
+Turn your image to a grayscale version using the `effectShadow` modifier.
+
+```html
+<NuxtImg
+  provider="imagekit"
+  src="/default-image.jpg"
+  height="300"
+  :modifiers="{effectShadow: 'bl-15_st-40_x-10_y-N5'}"
+/>
+```
+
+### `effectGradient`
+
+Turn your image to a grayscale version using the `effectGradient` modifier.
+
+```html
+<NuxtImg
+  provider="imagekit"
+  src="/default-image.jpg"
+  height="300"
+  :modifiers="{effectGradient: 'from-red_to-white'}"
+/>
+```
 
 ### `named`
 
@@ -252,6 +277,8 @@ ImageKit's Nuxt Image integration provides an easy-to-remember name for each tra
 | effectUSM | e-usm |
 | effectContrast | e-contrast |
 | effectGray | e-grayscale |
+| effectShadow | e-shadow |
+| effectGradient | e-gradient |
 | original | orig |
 
 > Learn more about [ImageKit's Image transformations](https://docs.imagekit.io/features/image-transformations) from the official documentation.

--- a/docs/content/3.providers/imagekit.md
+++ b/docs/content/3.providers/imagekit.md
@@ -76,7 +76,7 @@ Turn your image to a grayscale version using the `effectGray` modifier.
 
 ### `effectShadow`
 
-Turn your image to a grayscale version using the `effectShadow` modifier.
+Add a shadow under solid objects in an input image with a transparent background using the `effectShadow` modifier.
 
 ```html
 <NuxtImg
@@ -89,7 +89,7 @@ Turn your image to a grayscale version using the `effectShadow` modifier.
 
 ### `effectGradient`
 
-Turn your image to a grayscale version using the `effectGradient` modifier.
+Add a gradient overlay over an input image using the `effectGradient` modifier.
 
 ```html
 <NuxtImg

--- a/src/runtime/providers/imagekit.ts
+++ b/src/runtime/providers/imagekit.ts
@@ -39,6 +39,8 @@ const operationsGenerator = createOperationsGenerator({
     effectUSM: 'e-usm',
     effectContrast: 'e-contrast',
     effectGray: 'e-grayscale',
+    effectShadow: 'e-shadow',
+    effectGradient: 'e-gradient',
     original: 'orig'
   },
   valueMap: {


### PR DESCRIPTION
We've included new modifiers called `effectShadow` to create a shadow effect beneath solid items in an image that has a clear background. Additionally, we've added `effectGradient` to put a gradient overlay on top of an image.