### PR TITLE
feat: add `useBackgroundImage` composable

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -102,6 +102,11 @@ export default defineNuxtModule<ModuleOptions>({
       from: resolver.resolve('runtime/composables')
     })
 
+    addImports({
+      name: 'useBackgroundImage',
+      from: resolver.resolve('runtime/composables')
+    })
+
     // Add components
     addComponent({
       name: 'NuxtImg',

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -1,9 +1,9 @@
-import type { $Img } from '../types'
-
+import type { $Img, ImageSizesOptions } from '../types'
+import { generateRandomString } from './utils'
 import { createImage } from './image'
 // @ts-expect-error virtual file
 import { imageOptions } from '#build/image-options'
-import { useNuxtApp, useRuntimeConfig } from '#imports'
+import { useNuxtApp, useRuntimeConfig, useHead } from '#imports'
 
 export const useImage = (): $Img => {
   const config = useRuntimeConfig()
@@ -15,4 +15,37 @@ export const useImage = (): $Img => {
       baseURL: config.app.baseURL
     }
   }))
+}
+
+export const useBackgroundImage = (src: string, options: Partial<ImageSizesOptions>) => {
+  const $img = useImage()
+  const bgSizes = $img.getBgSizes(src, options)
+  const cls = 'nuxt-bg-' + generateRandomString()
+  const defaultBg = bgSizes.get('default')
+
+  // TODO: handle Map item type
+  const toCSS = (bgs: any[]) => {
+    const imageSets = bgs.map((bg) => {
+      const density = bg.density ? `${bg.density}x` : ''
+      const type = bg.type ? `type("${bg.type}")` : ''
+      return `url('${bg.src}') ${density} ${type}`
+    })
+    return `background-image: url(${bgs[0].src});background-image: image-set(${imageSets.join(', ')});`
+  }
+  const defaultBgCSS = defaultBg ? `.${cls}{${toCSS(defaultBg)}}` : ''
+  bgSizes.delete('default')
+  const css = Array.from(bgSizes).reverse().map(([key, value]) => {
+    return `@media (max-width: ${key}px) { .${cls} { ${toCSS(value)} } }`
+  })
+
+  useHead({
+    style: [
+      {
+        id: cls,
+        innerHTML: defaultBgCSS + css.join(' ')
+      }
+    ]
+  })
+
+  return cls
 }

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -60,14 +60,17 @@ export const useBackgroundImage = (
     })
   }
 
-  useHead({
-    style: [
-      {
-        id: cls,
-        innerHTML: css
-      }
-    ]
-  })
+  // prevent hydration mismatch: because id is generated randomly
+  if (import.meta.client) {
+    useHead({
+      style: [
+        {
+          id: cls,
+          innerHTML: css
+        }
+      ]
+    })
+  }
 
   return cls
 }

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -303,13 +303,16 @@ export function createBgSizes (
   // sort by screenMaxWidth (ascending)
   variants.sort((v1, v2) => v1.screenMaxWidth - v2.screenMaxWidth)
 
-  const result: BgImageSizes = new Map()
   const densities = opts.densities?.trim()
     ? parseDensities(opts.densities.trim())
     : ctx.options.densities
   // sort densities ascending
   densities.sort((a, b) => a - b)
   checkDensities(densities)
+
+  const quality = opts.modifiers?.quality ? opts.modifiers.quality : ctx.options.quality
+
+  const result: BgImageSizes = new Map()
 
   variants.forEach((variant, i) => {
     const bpsWidth = String(variants[i + 1]?.screenMaxWidth || 'default')
@@ -320,8 +323,15 @@ export function createBgSizes (
       bpsWidth,
       densities.map((d) => {
         return {
-          src: getVariantSrc(ctx, input, opts as ImageSizesOptions, variant, d),
-          density: d.toString()
+          src: getVariantSrc(ctx, input, {
+            ...opts,
+            modifiers: {
+              ...opts.modifiers,
+              quality
+            }
+          } as ImageSizesOptions, variant, d),
+          density: d.toString(),
+          type: opts.modifiers?.format ? `image/${opts.modifiers.format}` : ''
         }
       })
     )
@@ -331,7 +341,15 @@ export function createBgSizes (
       'default',
       densities.map((d) => {
         return {
-          src: ctx.$img!(input, opts.modifiers, opts),
+          src: ctx.$img!(
+            input,
+            {
+              ...opts.modifiers,
+              quality,
+              width: width ? width * d : undefined,
+              height: height ? height * d : undefined
+            },
+            opts),
           density: d.toString(),
           type: opts.modifiers?.format ? `image/${opts.modifiers.format}` : ''
         }

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -133,3 +133,12 @@ export function parseSizes (input: Record<string, string | number> | string): Re
   }
   return sizes
 }
+
+export function generateRandomString (length: number = 6): string {
+  let result = ''
+  const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+  for (let i = 0; i < length; i++) {
+    result += characters.charAt(Math.floor(Math.random() * characters.length))
+  }
+  return result
+}

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -70,6 +70,7 @@ export type BgImageSizes = Map<string, {
   src: string
   density?: string
   type?: string
+  _cWidth?: number
 }[]>
 
 export interface Img {
@@ -78,7 +79,7 @@ export interface Img {
   getImage: (source: string, options?: ImageOptions) => ResolvedImage
   getSizes: (source: string, options?: ImageOptions, sizes?: string[]) => ImageSizes
   getMeta: (source: string, options?: ImageOptions) => Promise<ImageInfo>
-  getBgSizes: (source: string, options?: Partial<ImageSizesOptions>) => BgImageSizes
+  getBgSizes: (source: string, options?: Partial<ImageSizesOptions>) => { imagesrcset: string, imagesizes: string, sizes: BgImageSizes }
 }
 
 export type $Img = Img & {

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -66,12 +66,19 @@ export interface ImageSizes {
   src: string
 }
 
+export type BgImageSizes = Map<string, {
+  src: string
+  density?: string
+  type?: string
+}[]>
+
 export interface Img {
   (source: string, modifiers?: ImageOptions['modifiers'], options?: ImageOptions): ResolvedImage['url']
   options: CreateImageOptions
   getImage: (source: string, options?: ImageOptions) => ResolvedImage
   getSizes: (source: string, options?: ImageOptions, sizes?: string[]) => ImageSizes
   getMeta: (source: string, options?: ImageOptions) => Promise<ImageInfo>
+  getBgSizes: (source: string, options?: Partial<ImageSizesOptions>) => BgImageSizes
 }
 
 export type $Img = Img & {

--- a/test/unit/backgroundImage.test.ts
+++ b/test/unit/backgroundImage.test.ts
@@ -32,12 +32,11 @@ describe('Renders simple image', () => {
 
   it('applies sizes', () => {
     const cls = useBackgroundImage(src, { sizes: '200,500:500,900:900' })
-
     expect(useHead).toBeCalledWith({
       style: [
         {
           id: cls,
-          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/image.png);background-image: image-set(url('/_ipx/w_900/image.png') 1x , url('/_ipx/w_1800/image.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/image.png);background-image: image-set(url('/_ipx/w_500/image.png') 1x , url('/_ipx/w_1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/image.png);background-image: image-set(url('/_ipx/w_200/image.png') 1x , url('/_ipx/w_400/image.png') 2x ); } }`
+          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/image.png);background-image: image-set(url('/_ipx/w_900/image.png') 1x , url('/_ipx/w_1800/image.png') 2x );} @media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/image.png);background-image: image-set(url('/_ipx/w_500/image.png') 1x , url('/_ipx/w_1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/image.png);background-image: image-set(url('/_ipx/w_200/image.png') 1x , url('/_ipx/w_400/image.png') 2x ); } }`
         }
       ]
     })
@@ -53,7 +52,7 @@ describe('Renders simple image', () => {
       style: [
         {
           id: cls,
-          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/image.png);background-image: image-set(url('/_ipx/w_900/image.png') 1x , url('/_ipx/w_1800/image.png') 2x , url('/_ipx/w_2700/image.png') 3x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/image.png);background-image: image-set(url('/_ipx/w_500/image.png') 1x , url('/_ipx/w_1000/image.png') 2x , url('/_ipx/w_1500/image.png') 3x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/image.png);background-image: image-set(url('/_ipx/w_200/image.png') 1x , url('/_ipx/w_400/image.png') 2x , url('/_ipx/w_600/image.png') 3x ); } }`
+          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/image.png);background-image: image-set(url('/_ipx/w_900/image.png') 1x , url('/_ipx/w_1800/image.png') 2x , url('/_ipx/w_2700/image.png') 3x );} @media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/image.png);background-image: image-set(url('/_ipx/w_500/image.png') 1x , url('/_ipx/w_1000/image.png') 2x , url('/_ipx/w_1500/image.png') 3x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/image.png);background-image: image-set(url('/_ipx/w_200/image.png') 1x , url('/_ipx/w_400/image.png') 2x , url('/_ipx/w_600/image.png') 3x ); } }`
         }
       ]
     })
@@ -69,7 +68,7 @@ describe('Renders simple image', () => {
       style: [
         {
           id: cls,
-          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/image.png);background-image: image-set(url('/_ipx/w_900/image.png') 1x , url('/_ipx/w_1800/image.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/image.png);background-image: image-set(url('/_ipx/w_500/image.png') 1x , url('/_ipx/w_1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/image.png);background-image: image-set(url('/_ipx/w_200/image.png') 1x , url('/_ipx/w_400/image.png') 2x ); } }`
+          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/image.png);background-image: image-set(url('/_ipx/w_900/image.png') 1x , url('/_ipx/w_1800/image.png') 2x );} @media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/image.png);background-image: image-set(url('/_ipx/w_500/image.png') 1x , url('/_ipx/w_1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/image.png);background-image: image-set(url('/_ipx/w_200/image.png') 1x , url('/_ipx/w_400/image.png') 2x ); } }`
         }
       ]
     })
@@ -85,7 +84,7 @@ describe('Renders simple image', () => {
       style: [
         {
           id: cls,
-          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/image.png);background-image: image-set(url('/_ipx/w_900/image.png') 1x , url('/_ipx/w_1800/image.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/image.png);background-image: image-set(url('/_ipx/w_500/image.png') 1x , url('/_ipx/w_1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/image.png);background-image: image-set(url('/_ipx/w_200/image.png') 1x , url('/_ipx/w_400/image.png') 2x ); } }`
+          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/image.png);background-image: image-set(url('/_ipx/w_900/image.png') 1x , url('/_ipx/w_1800/image.png') 2x );} @media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/image.png);background-image: image-set(url('/_ipx/w_500/image.png') 1x , url('/_ipx/w_1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/image.png);background-image: image-set(url('/_ipx/w_200/image.png') 1x , url('/_ipx/w_400/image.png') 2x ); } }`
         }
       ]
     })
@@ -137,7 +136,7 @@ describe('Renders simple image', () => {
       style: [
         {
           id: cls,
-          innerHTML: `.${cls}{background-image: url(/_ipx/s_800x1200/image.png);background-image: image-set(url('/_ipx/s_800x1200/image.png') 1x , url('/_ipx/s_1600x2400/image.png') 2x );}@media (max-width: 800px) { .${cls} { background-image: url(/_ipx/s_500x750/image.png);background-image: image-set(url('/_ipx/s_500x750/image.png') 1x , url('/_ipx/s_1000x1500/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/s_400x600/image.png);background-image: image-set(url('/_ipx/s_400x600/image.png') 1x , url('/_ipx/s_800x1200/image.png') 2x ); } } @media (max-width: 400px) { .${cls} { background-image: url(/_ipx/s_200x300/image.png);background-image: image-set(url('/_ipx/s_200x300/image.png') 1x , url('/_ipx/s_400x600/image.png') 2x ); } } @media (max-width: 300px) { .${cls} { background-image: url(/_ipx/s_200x300/image.png);background-image: image-set(url('/_ipx/s_200x300/image.png') 1x , url('/_ipx/s_400x600/image.png') 2x ); } }`
+          innerHTML: `.${cls}{background-image: url(/_ipx/s_800x1200/image.png);background-image: image-set(url('/_ipx/s_800x1200/image.png') 1x , url('/_ipx/s_1600x2400/image.png') 2x );} @media (max-width: 800px) { .${cls} { background-image: url(/_ipx/s_500x750/image.png);background-image: image-set(url('/_ipx/s_500x750/image.png') 1x , url('/_ipx/s_1000x1500/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/s_400x600/image.png);background-image: image-set(url('/_ipx/s_400x600/image.png') 1x , url('/_ipx/s_800x1200/image.png') 2x ); } } @media (max-width: 400px) { .${cls} { background-image: url(/_ipx/s_200x300/image.png);background-image: image-set(url('/_ipx/s_200x300/image.png') 1x , url('/_ipx/s_400x600/image.png') 2x ); } } @media (max-width: 300px) { .${cls} { background-image: url(/_ipx/s_200x300/image.png);background-image: image-set(url('/_ipx/s_200x300/image.png') 1x , url('/_ipx/s_400x600/image.png') 2x ); } }`
         }
       ]
     })
@@ -152,7 +151,7 @@ describe('Renders simple image', () => {
       style: [
         {
           id: cls,
-          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/%E6%B1%89%E5%AD%97.png);background-image: image-set(url('/_ipx/w_900/%E6%B1%89%E5%AD%97.png') 1x , url('/_ipx/w_1800/%E6%B1%89%E5%AD%97.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/%E6%B1%89%E5%AD%97.png);background-image: image-set(url('/_ipx/w_500/%E6%B1%89%E5%AD%97.png') 1x , url('/_ipx/w_1000/%E6%B1%89%E5%AD%97.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/%E6%B1%89%E5%AD%97.png);background-image: image-set(url('/_ipx/w_200/%E6%B1%89%E5%AD%97.png') 1x , url('/_ipx/w_400/%E6%B1%89%E5%AD%97.png') 2x ); } }`
+          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/%E6%B1%89%E5%AD%97.png);background-image: image-set(url('/_ipx/w_900/%E6%B1%89%E5%AD%97.png') 1x , url('/_ipx/w_1800/%E6%B1%89%E5%AD%97.png') 2x );} @media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/%E6%B1%89%E5%AD%97.png);background-image: image-set(url('/_ipx/w_500/%E6%B1%89%E5%AD%97.png') 1x , url('/_ipx/w_1000/%E6%B1%89%E5%AD%97.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/%E6%B1%89%E5%AD%97.png);background-image: image-set(url('/_ipx/w_200/%E6%B1%89%E5%AD%97.png') 1x , url('/_ipx/w_400/%E6%B1%89%E5%AD%97.png') 2x ); } }`
         }
       ]
     })
@@ -171,7 +170,7 @@ describe('Renders simple image', () => {
       style: [
         {
           id: cls,
-          innerHTML: `.${cls}{background-image: url(/_ipx/s_350x700/image.png);background-image: image-set(url('/_ipx/s_350x700/image.png') 1x , url('/_ipx/s_700x1400/image.png') 2x );}@media (max-width: 1536px) { .${cls} { background-image: url(/_ipx/s_350x700/image.png);background-image: image-set(url('/_ipx/s_350x700/image.png') 1x , url('/_ipx/s_700x1400/image.png') 2x ); } } @media (max-width: 1280px) { .${cls} { background-image: url(/_ipx/s_350x700/image.png);background-image: image-set(url('/_ipx/s_350x700/image.png') 1x , url('/_ipx/s_700x1400/image.png') 2x ); } } @media (max-width: 1024px) { .${cls} { background-image: url(/_ipx/s_300x600/image.png);background-image: image-set(url('/_ipx/s_300x600/image.png') 1x , url('/_ipx/s_600x1200/image.png') 2x ); } } @media (max-width: 768px) { .${cls} { background-image: url(/_ipx/s_640x1280/image.png);background-image: image-set(url('/_ipx/s_640x1280/image.png') 1x , url('/_ipx/s_1280x2560/image.png') 2x ); } } @media (max-width: 640px) { .${cls} { background-image: url(/_ipx/s_320x640/image.png);background-image: image-set(url('/_ipx/s_320x640/image.png') 1x , url('/_ipx/s_640x1280/image.png') 2x ); } }`
+          innerHTML: `.${cls}{background-image: url(/_ipx/s_350x700/image.png);background-image: image-set(url('/_ipx/s_350x700/image.png') 1x , url('/_ipx/s_700x1400/image.png') 2x );} @media (max-width: 1536px) { .${cls} { background-image: url(/_ipx/s_350x700/image.png);background-image: image-set(url('/_ipx/s_350x700/image.png') 1x , url('/_ipx/s_700x1400/image.png') 2x ); } } @media (max-width: 1280px) { .${cls} { background-image: url(/_ipx/s_350x700/image.png);background-image: image-set(url('/_ipx/s_350x700/image.png') 1x , url('/_ipx/s_700x1400/image.png') 2x ); } } @media (max-width: 1024px) { .${cls} { background-image: url(/_ipx/s_300x600/image.png);background-image: image-set(url('/_ipx/s_300x600/image.png') 1x , url('/_ipx/s_600x1200/image.png') 2x ); } } @media (max-width: 768px) { .${cls} { background-image: url(/_ipx/s_640x1280/image.png);background-image: image-set(url('/_ipx/s_640x1280/image.png') 1x , url('/_ipx/s_1280x2560/image.png') 2x ); } } @media (max-width: 640px) { .${cls} { background-image: url(/_ipx/s_320x640/image.png);background-image: image-set(url('/_ipx/s_320x640/image.png') 1x , url('/_ipx/s_640x1280/image.png') 2x ); } }`
         }
       ]
     })
@@ -219,7 +218,7 @@ describe('Renders image, applies module config', () => {
       style: [
         {
           id: cls,
-          innerHTML: `.${cls}{background-image: url(/_ipx/q_75&s_900x900/image.png);background-image: image-set(url('/_ipx/q_75&s_900x900/image.png') 1x , url('/_ipx/q_75&s_1800x1800/image.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/q_75&s_500x500/image.png);background-image: image-set(url('/_ipx/q_75&s_500x500/image.png') 1x , url('/_ipx/q_75&s_1000x1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/q_75&s_200x200/image.png);background-image: image-set(url('/_ipx/q_75&s_200x200/image.png') 1x , url('/_ipx/q_75&s_400x400/image.png') 2x ); } }`
+          innerHTML: `.${cls}{background-image: url(/_ipx/q_75&s_900x900/image.png);background-image: image-set(url('/_ipx/q_75&s_900x900/image.png') 1x , url('/_ipx/q_75&s_1800x1800/image.png') 2x );} @media (max-width: 900px) { .${cls} { background-image: url(/_ipx/q_75&s_500x500/image.png);background-image: image-set(url('/_ipx/q_75&s_500x500/image.png') 1x , url('/_ipx/q_75&s_1000x1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/q_75&s_200x200/image.png);background-image: image-set(url('/_ipx/q_75&s_200x200/image.png') 1x , url('/_ipx/q_75&s_400x400/image.png') 2x ); } }`
         }
       ]
     })
@@ -242,7 +241,7 @@ describe('Renders image, applies module config', () => {
       style: [
         {
           id: cls,
-          innerHTML: `.${cls}{background-image: url(/_ipx/q_90&s_900x900/image.png);background-image: image-set(url('/_ipx/q_90&s_900x900/image.png') 1x , url('/_ipx/q_90&s_1800x1800/image.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/q_90&s_500x500/image.png);background-image: image-set(url('/_ipx/q_90&s_500x500/image.png') 1x , url('/_ipx/q_90&s_1000x1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/q_90&s_200x200/image.png);background-image: image-set(url('/_ipx/q_90&s_200x200/image.png') 1x , url('/_ipx/q_90&s_400x400/image.png') 2x ); } }`
+          innerHTML: `.${cls}{background-image: url(/_ipx/q_90&s_900x900/image.png);background-image: image-set(url('/_ipx/q_90&s_900x900/image.png') 1x , url('/_ipx/q_90&s_1800x1800/image.png') 2x );} @media (max-width: 900px) { .${cls} { background-image: url(/_ipx/q_90&s_500x500/image.png);background-image: image-set(url('/_ipx/q_90&s_500x500/image.png') 1x , url('/_ipx/q_90&s_1000x1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/q_90&s_200x200/image.png);background-image: image-set(url('/_ipx/q_90&s_200x200/image.png') 1x , url('/_ipx/q_90&s_400x400/image.png') 2x ); } }`
         }
       ]
     })
@@ -264,7 +263,7 @@ describe('Renders image, applies module config', () => {
       style: [
         {
           id: cls,
-          innerHTML: `.${cls}{background-image: url(/_ipx/s_900x900/image.png);background-image: image-set(url('/_ipx/s_900x900/image.png') 1x , url('/_ipx/s_1800x1800/image.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/s_500x500/image.png);background-image: image-set(url('/_ipx/s_500x500/image.png') 1x , url('/_ipx/s_1000x1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/s_200x200/image.png);background-image: image-set(url('/_ipx/s_200x200/image.png') 1x , url('/_ipx/s_400x400/image.png') 2x ); } }`
+          innerHTML: `.${cls}{background-image: url(/_ipx/s_900x900/image.png);background-image: image-set(url('/_ipx/s_900x900/image.png') 1x , url('/_ipx/s_1800x1800/image.png') 2x );} @media (max-width: 900px) { .${cls} { background-image: url(/_ipx/s_500x500/image.png);background-image: image-set(url('/_ipx/s_500x500/image.png') 1x , url('/_ipx/s_1000x1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/s_200x200/image.png);background-image: image-set(url('/_ipx/s_200x200/image.png') 1x , url('/_ipx/s_400x400/image.png') 2x ); } }`
         }
       ]
     })

--- a/test/unit/backgroundImage.test.ts
+++ b/test/unit/backgroundImage.test.ts
@@ -1,0 +1,272 @@
+// @vitest-environment nuxt
+
+import type { Mock } from 'vitest'
+import { beforeEach, describe, it, expect, vi } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+// @ts-expect-error virtual file
+import { imageOptions } from '#build/image-options'
+import { createImage } from '#image'
+import { useBackgroundImage, useHead, useNuxtApp } from '#imports'
+
+mockNuxtImport('useHead', () => {
+  return vi.fn()
+})
+describe('Renders simple image', () => {
+  const src = '/image.png'
+
+  beforeEach(() => {
+    (useHead as Mock).mockClear()
+  })
+
+  it('only src', () => {
+    const cls = useBackgroundImage(src, {})
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/_/image.png);background-image: image-set(url('/_ipx/_/image.png') 1x , url('/_ipx/_/image.png') 2x );}`
+        }
+      ]
+    })
+  })
+
+  it('applies sizes', () => {
+    const cls = useBackgroundImage(src, { sizes: '200,500:500,900:900' })
+
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/image.png);background-image: image-set(url('/_ipx/w_900/image.png') 1x , url('/_ipx/w_1800/image.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/image.png);background-image: image-set(url('/_ipx/w_500/image.png') 1x , url('/_ipx/w_1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/image.png);background-image: image-set(url('/_ipx/w_200/image.png') 1x , url('/_ipx/w_400/image.png') 2x ); } }`
+        }
+      ]
+    })
+  })
+
+  it('applies densities', () => {
+    const cls = useBackgroundImage(src, {
+      sizes: '200,500:500,900:900',
+      densities: '1x 2x 3x'
+    })
+
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/image.png);background-image: image-set(url('/_ipx/w_900/image.png') 1x , url('/_ipx/w_1800/image.png') 2x , url('/_ipx/w_2700/image.png') 3x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/image.png);background-image: image-set(url('/_ipx/w_500/image.png') 1x , url('/_ipx/w_1000/image.png') 2x , url('/_ipx/w_1500/image.png') 3x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/image.png);background-image: image-set(url('/_ipx/w_200/image.png') 1x , url('/_ipx/w_400/image.png') 2x , url('/_ipx/w_600/image.png') 3x ); } }`
+        }
+      ]
+    })
+  })
+
+  it('empty densities (fallback to global)', () => {
+    const cls = useBackgroundImage(src, {
+      sizes: '200,500:500,900:900',
+      densities: ''
+    })
+
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/image.png);background-image: image-set(url('/_ipx/w_900/image.png') 1x , url('/_ipx/w_1800/image.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/image.png);background-image: image-set(url('/_ipx/w_500/image.png') 1x , url('/_ipx/w_1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/image.png);background-image: image-set(url('/_ipx/w_200/image.png') 1x , url('/_ipx/w_400/image.png') 2x ); } }`
+        }
+      ]
+    })
+  })
+
+  it('empty string densities (fallback to global)', () => {
+    const cls = useBackgroundImage(src, {
+      sizes: '200,500:500,900:900',
+      densities: '  '
+    })
+
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/image.png);background-image: image-set(url('/_ipx/w_900/image.png') 1x , url('/_ipx/w_1800/image.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/image.png);background-image: image-set(url('/_ipx/w_500/image.png') 1x , url('/_ipx/w_1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/image.png);background-image: image-set(url('/_ipx/w_200/image.png') 1x , url('/_ipx/w_400/image.png') 2x ); } }`
+        }
+      ]
+    })
+  })
+
+  it('error on invalid densities', () => {
+    expect(() =>
+      useBackgroundImage(src, { sizes: '200,500:500,900:900', densities: 'x' })
+    ).toThrow(Error)
+  })
+
+  it('with single sizes entry', () => {
+    const cls = useBackgroundImage(src, {
+      sizes: '150',
+      modifiers: { width: 300, height: 400 }
+    })
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/s_150x200/image.png);background-image: image-set(url('/_ipx/s_150x200/image.png') 1x , url('/_ipx/s_300x400/image.png') 2x );}`
+        }
+      ]
+    })
+  })
+
+  it('with single sizes entry (responsive)', () => {
+    const cls = useBackgroundImage(src, {
+      sizes: 'sm:150',
+      modifiers: { width: 300, height: 400 }
+    })
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/s_150x200/image.png);background-image: image-set(url('/_ipx/s_150x200/image.png') 1x , url('/_ipx/s_300x400/image.png') 2x );}`
+        }
+      ]
+    })
+  })
+
+  it('de-duplicates sizes', () => {
+    const cls = useBackgroundImage(src, {
+      sizes: '200:200px,300:200px,400:400px,400:400px,500:500px,800:800px',
+      modifiers: { width: 200, height: 300 }
+    })
+
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/s_800x1200/image.png);background-image: image-set(url('/_ipx/s_800x1200/image.png') 1x , url('/_ipx/s_1600x2400/image.png') 2x );}@media (max-width: 800px) { .${cls} { background-image: url(/_ipx/s_500x750/image.png);background-image: image-set(url('/_ipx/s_500x750/image.png') 1x , url('/_ipx/s_1000x1500/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/s_400x600/image.png);background-image: image-set(url('/_ipx/s_400x600/image.png') 1x , url('/_ipx/s_800x1200/image.png') 2x ); } } @media (max-width: 400px) { .${cls} { background-image: url(/_ipx/s_200x300/image.png);background-image: image-set(url('/_ipx/s_200x300/image.png') 1x , url('/_ipx/s_400x600/image.png') 2x ); } } @media (max-width: 300px) { .${cls} { background-image: url(/_ipx/s_200x300/image.png);background-image: image-set(url('/_ipx/s_200x300/image.png') 1x , url('/_ipx/s_400x600/image.png') 2x ); } }`
+        }
+      ]
+    })
+  })
+
+  it('encodes characters', () => {
+    const cls = useBackgroundImage('/汉字.png', {
+      sizes: '200,500:500,900:900'
+    })
+
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/w_900/%E6%B1%89%E5%AD%97.png);background-image: image-set(url('/_ipx/w_900/%E6%B1%89%E5%AD%97.png') 1x , url('/_ipx/w_1800/%E6%B1%89%E5%AD%97.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/w_500/%E6%B1%89%E5%AD%97.png);background-image: image-set(url('/_ipx/w_500/%E6%B1%89%E5%AD%97.png') 1x , url('/_ipx/w_1000/%E6%B1%89%E5%AD%97.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/w_200/%E6%B1%89%E5%AD%97.png);background-image: image-set(url('/_ipx/w_200/%E6%B1%89%E5%AD%97.png') 1x , url('/_ipx/w_400/%E6%B1%89%E5%AD%97.png') 2x ); } }`
+        }
+      ]
+    })
+  })
+
+  it('correctly sets crop', () => {
+    const cls = useBackgroundImage('/image.png', {
+      modifiers: {
+        width: 1000,
+        height: 2000
+      },
+      sizes: 'xs:100vw sm:100vw md:300px lg:350px xl:350px 2xl:350px'
+    })
+
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/s_350x700/image.png);background-image: image-set(url('/_ipx/s_350x700/image.png') 1x , url('/_ipx/s_700x1400/image.png') 2x );}@media (max-width: 1536px) { .${cls} { background-image: url(/_ipx/s_350x700/image.png);background-image: image-set(url('/_ipx/s_350x700/image.png') 1x , url('/_ipx/s_700x1400/image.png') 2x ); } } @media (max-width: 1280px) { .${cls} { background-image: url(/_ipx/s_350x700/image.png);background-image: image-set(url('/_ipx/s_350x700/image.png') 1x , url('/_ipx/s_700x1400/image.png') 2x ); } } @media (max-width: 1024px) { .${cls} { background-image: url(/_ipx/s_300x600/image.png);background-image: image-set(url('/_ipx/s_300x600/image.png') 1x , url('/_ipx/s_600x1200/image.png') 2x ); } } @media (max-width: 768px) { .${cls} { background-image: url(/_ipx/s_640x1280/image.png);background-image: image-set(url('/_ipx/s_640x1280/image.png') 1x , url('/_ipx/s_1280x2560/image.png') 2x ); } } @media (max-width: 640px) { .${cls} { background-image: url(/_ipx/s_320x640/image.png);background-image: image-set(url('/_ipx/s_320x640/image.png') 1x , url('/_ipx/s_640x1280/image.png') 2x ); } }`
+        }
+      ]
+    })
+  })
+
+  it('without sizes, but densities', () => {
+    const cls = useBackgroundImage(src, {
+      modifiers: { width: 300, height: 400 },
+      densities: '1x 2x 3x'
+    })
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/s_300x400/image.png);background-image: image-set(url('/_ipx/s_300x400/image.png') 1x , url('/_ipx/s_600x800/image.png') 2x , url('/_ipx/s_900x1200/image.png') 3x );}`
+        }
+      ]
+    })
+  })
+})
+
+describe('Renders image, applies module config', () => {
+  const nuxtApp = useNuxtApp()
+  const config = useRuntimeConfig()
+  const src = '/image.png'
+
+  beforeEach(() => {
+    delete nuxtApp._img
+  })
+
+  it('Module config .quality applies', () => {
+    nuxtApp._img = createImage({
+      ...imageOptions,
+      nuxt: {
+        baseURL: config.app.baseURL
+      },
+      quality: 75
+    })
+    const cls = useBackgroundImage(src, {
+      modifiers: { width: 200, height: 200 },
+      sizes: '200,500:500,900:900'
+    })
+
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/q_75&s_900x900/image.png);background-image: image-set(url('/_ipx/q_75&s_900x900/image.png') 1x , url('/_ipx/q_75&s_1800x1800/image.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/q_75&s_500x500/image.png);background-image: image-set(url('/_ipx/q_75&s_500x500/image.png') 1x , url('/_ipx/q_75&s_1000x1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/q_75&s_200x200/image.png);background-image: image-set(url('/_ipx/q_75&s_200x200/image.png') 1x , url('/_ipx/q_75&s_400x400/image.png') 2x ); } }`
+        }
+      ]
+    })
+  })
+
+  it('Module config .quality + props.quality => props.quality applies', () => {
+    nuxtApp._img = createImage({
+      ...imageOptions,
+      nuxt: {
+        baseURL: config.app.baseURL
+      },
+      quality: 75
+    })
+    const cls = useBackgroundImage(src, {
+      modifiers: { width: 200, height: 200, quality: 90 },
+      sizes: '200,500:500,900:900'
+    })
+
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/q_90&s_900x900/image.png);background-image: image-set(url('/_ipx/q_90&s_900x900/image.png') 1x , url('/_ipx/q_90&s_1800x1800/image.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/q_90&s_500x500/image.png);background-image: image-set(url('/_ipx/q_90&s_500x500/image.png') 1x , url('/_ipx/q_90&s_1000x1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/q_90&s_200x200/image.png);background-image: image-set(url('/_ipx/q_90&s_200x200/image.png') 1x , url('/_ipx/q_90&s_400x400/image.png') 2x ); } }`
+        }
+      ]
+    })
+  })
+
+  it('Without quality config => default image', () => {
+    nuxtApp._img = createImage({
+      ...imageOptions,
+      nuxt: {
+        baseURL: config.app.baseURL
+      }
+    })
+    const cls = useBackgroundImage(src, {
+      modifiers: { width: 200, height: 200 },
+      sizes: '200,500:500,900:900'
+    })
+
+    expect(useHead).toBeCalledWith({
+      style: [
+        {
+          id: cls,
+          innerHTML: `.${cls}{background-image: url(/_ipx/s_900x900/image.png);background-image: image-set(url('/_ipx/s_900x900/image.png') 1x , url('/_ipx/s_1800x1800/image.png') 2x );}@media (max-width: 900px) { .${cls} { background-image: url(/_ipx/s_500x500/image.png);background-image: image-set(url('/_ipx/s_500x500/image.png') 1x , url('/_ipx/s_1000x1000/image.png') 2x ); } } @media (max-width: 500px) { .${cls} { background-image: url(/_ipx/s_200x200/image.png);background-image: image-set(url('/_ipx/s_200x200/image.png') 1x , url('/_ipx/s_400x400/image.png') 2x ); } }`
+        }
+      ]
+    })
+  })
+})


### PR DESCRIPTION
Add a `useBackgroundImage` composable to enable the background to use the same functionality as `<nuxt-img>`.

## Usage
```vue
<script setup lang="ts">
  const cls = useBackgroundImage('/images/nuxt.png', {
    provider: 'ipx',
    sizes: '200,500:500,900:900',
    modifiers: {
      width: 300,
      height: 300,
      // others...
    },
    densities: "1x 2x",
    preload: true,
    nonce: 'any nonce',
  })
</script>
<template>
  <div
    :class="cls"
    :style="{
      width: '300px',
      height: '300px',
      backgroundSize: 'cover',
      backgroundRepeat: 'no-repeat',
      backgroundPosition: 'center'
    }"
  />
</template>
```