### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/docs/content/1.get-started/1.installation.md
+++ b/docs/content/1.get-started/1.installation.md
@@ -8,21 +8,9 @@ You are reading the `v1` documentation compatible with **Nuxt 3**. :br Checkout 
 ::
 
 Add `@nuxt/image` dependency to your project:
-
-::code-group
-```bash [pnpm]
-pnpm add @nuxt/image
+```bash
+npx nuxi@latest module add image
 ```
-```bash [yarn]
-yarn add @nuxt/image
-```
-```bash [npm]
-npm install @nuxt/image
-```
-```bash [bun]
-bun add @nuxt/image
-```
-::
 
 Add it to `modules` in your `nuxt.config`:
 

--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -13,7 +13,7 @@ useSeoMeta({
   ogImage: 'https://image.nuxt.com/social-card.png',
   twitterImage: 'https://image.nuxt.com/social-card.png',
 })
-const source = ref('npm i @nuxt/image')
+const source = ref('npx nuxi@latest module add image
 const { copy, copied } = useClipboard({ source })
 
 const providers = ['caisy', 'bunny', 'cloudflare', 'cloudimage', 'cloudinary', 'directus', 'edgio', 'fastly', 'glide', 'gumlet', 'hygraph', 'imageengine', 'imagekit', 'imgix', 'ipx', 'netlify', 'prepr', 'prismic', 'sanity', 'storyblok', 'strapi', 'twicpics', 'unsplash', 'uploadcare', 'vercel', 'weserv']

--- a/docs/pages/index.vue
+++ b/docs/pages/index.vue
@@ -13,7 +13,7 @@ useSeoMeta({
   ogImage: 'https://image.nuxt.com/social-card.png',
   twitterImage: 'https://image.nuxt.com/social-card.png',
 })
-const source = ref('npx nuxi@latest module add image
+const source = ref('npx nuxi@latest module add image')
 const { copy, copied } = useClipboard({ source })
 
 const providers = ['caisy', 'bunny', 'cloudflare', 'cloudimage', 'cloudinary', 'directus', 'edgio', 'fastly', 'glide', 'gumlet', 'hygraph', 'imageengine', 'imagekit', 'imgix', 'ipx', 'netlify', 'prepr', 'prismic', 'sanity', 'storyblok', 'strapi', 'twicpics', 'unsplash', 'uploadcare', 'vercel', 'weserv']


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
