### PR TITLE
feat: implement responsive height to sizes prop

### DIFF
--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -108,24 +108,33 @@ export function parseDensities (input: string | undefined = ''): number[] {
 
 export function checkDensities (densities: number[]) {
   if (densities.length === 0) {
-    throw new Error('`densities` must not be empty, configure to `1` to render regular size only (DPR 1.0)')
+    throw new Error(
+      '`densities` must not be empty, configure to `1` to render regular size only (DPR 1.0)'
+    )
   }
   if (process.dev && Array.from(densities).some(d => d > 2)) {
     // eslint-disable-next-line no-console
-    console.warn('[nuxt] [image] Density values above `2` are not recommended. See https://observablehq.com/@eeeps/visual-acuity-and-device-pixel-ratio.')
+    console.warn(
+      '[nuxt] [image] Density values above `2` are not recommended. See https://observablehq.com/@eeeps/visual-acuity-and-device-pixel-ratio.'
+    )
   }
 }
 
-export function parseSizes (input: Record<string, string | number> | string): Record<string, string> {
+export function parseSizes (
+  input: Record<string, string | number> | string
+): Record<string, string> {
   const sizes: Record<string, string> = {}
   // string => object
   if (typeof input === 'string') {
     for (const entry of input.split(/[\s,]+/).filter(e => e)) {
-      const s = entry.split(':')
-      if (s.length !== 2) {
-        sizes['1px'] = s[0].trim()
+      const sizeParts = entry.split(':')
+      if (sizeParts.length !== 2) {
+        const [size] = sizeParts
+        const DEFAULT_BREAKPOINT = '1px'
+        sizes[DEFAULT_BREAKPOINT] = size.trim()
       } else {
-        sizes[s[0].trim()] = s[1].trim()
+        const [breakpoint, size] = sizeParts
+        sizes[breakpoint.trim()] = size.trim()
       }
     }
   } else {

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -116,3 +116,15 @@ export interface ImageSizesVariant {
   _cWidth: number
   _cHeight?: number | undefined
 }
+
+export type WidthAndHeightFromSize = {
+  widthFromSize: string;
+  heightFromSize: string | null;
+};
+
+export type HandleVariantHeightOptions = {
+  heightFromSize:WidthAndHeightFromSize['heightFromSize'];
+  hwRatio:number;
+  _cWidth:number;
+  height?:number;
+}

--- a/test/unit/image.test.ts
+++ b/test/unit/image.test.ts
@@ -156,6 +156,15 @@ describe('Renders simple image', () => {
     const domNonce = img.element.getAttribute('nonce')
     expect(domNonce).toBe('stub-nonce')
   })
+
+  it('works with responsive height', () => {
+    const img = mountImage({
+      src: '/image.png',
+      sizes: '100px/20px sm:100px/10px md:10px lg:200px/50px',
+      densities: 'x1 x2'
+    })
+    expect(img.html()).toMatchInlineSnapshot('"<img src="/_ipx/s_400x100/image.png" data-nuxt-img="" sizes="(max-width: 640px) 100px, (max-width: 768px) 100px, (max-width: 1024px) 10px, 200px" srcset="/_ipx/w_10/image.png 10w, /_ipx/w_20/image.png 20w, /_ipx/s_100x10/image.png 100w, /_ipx/s_200x50/image.png 200w, /_ipx/s_400x100/image.png 400w">"')
+  })
 })
 
 const getImageLoad = (cb = () => {}) => {


### PR DESCRIPTION
Implemented feature to add responsive sizes in `sizes` prop.
You can use it by adding `/` after width.
e.g.
```
sizes="200px/200px md:500px/250px lg:100vw/250px"
```
