### PR TITLE
docs: fix typo in get-started/installation

### DIFF
--- a/docs/content/1.get-started/1.installation.md
+++ b/docs/content/1.get-started/1.installation.md
@@ -105,6 +105,6 @@ If an error occurs during installation:
   npx nuxt@latest upgrade --force
   ```
 
-- If there is still an error related to `sharp` and `node-gyp`, it is is probably becase your OS architecture or NodeJS version is not included in pre-built binaries and needs to built from source (for example, this sometimes occurs on Apple M1). Checkout [node-gyp](https://github.com/nodejs/node-gyp#installation) for install requirements.
+- If there is still an error related to `sharp` and `node-gyp`, it is probably because your OS architecture or NodeJS version is not included in pre-built binaries and needs to be built from source (for example, this sometimes occurs on Apple M1). Checkout [node-gyp](https://github.com/nodejs/node-gyp#installation) for install requirements.
 
 - If none of the above worked, please [open an issue](https://github.com/nuxt/image/issues) and include error trace, OS, Node version and the package manager used for installing.


### PR DESCRIPTION
Just a quick fix. There are some typos in the sentence.