### PR TITLE
fix(cloudinary): map `cover` to cloudinary's `lfill` mode

### DIFF
--- a/src/runtime/providers/cloudinary.ts
+++ b/src/runtime/providers/cloudinary.ts
@@ -37,7 +37,7 @@ const operationsGenerator = createOperationsGenerator({
       fill: 'fill',
       inside: 'pad',
       outside: 'lpad',
-      cover: 'fit',
+      cover: 'lfill',
       contain: 'scale',
       minCover: 'mfit',
       minInside: 'mpad',


### PR DESCRIPTION
This fixes the mapping for the default "cover" fit mode between nuxt-image and cloudinary.

It was previously mapped to cloudinary's "fit" mode where it should be mapped to their "lfill" mode.

Related to issue #1354 