### PR TITLE
fix: nuxtpicture placeholder

### DIFF
--- a/playground/pages/picture.vue
+++ b/playground/pages/picture.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <h1>Original</h1>
     <nuxt-picture
       src="/images/colors.jpg"
       format="avif,webp"
@@ -8,6 +9,16 @@
       @load="isLoaded = true"
     />
     <p>Received onLoad event: {{ isLoaded }}</p>
+    <h1>Placeholder</h1>
+    <nuxt-picture
+      src="/images/colors.jpg"
+      placeholder
+      format="avif,webp"
+      width="500"
+      height="500"
+      @load="isLoaded2 = true"
+    />
+    <p>Received onLoad event: {{ isLoaded2 }}</p>
   </div>
 </template>
 
@@ -15,4 +26,5 @@
 import { ref } from '#imports'
 
 const isLoaded = ref(false)
+const isLoaded2 = ref(false)
 </script>


### PR DESCRIPTION
Closes #1160.

Adds placeholder behavior to NuxtPicture by initially setting the img element's src tag to the placeholder, waiting for the main src to load, and then showing the image. 

