### PR TITLE
fix(setup): Setup provider using the `provider` key

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -137,11 +137,12 @@ export async function resolveProvider(_nuxt: any, key: string, input: InputProvi
   }
 
   const resolver = createResolver(import.meta.url)
+  
+  const setup = input.setup || providerSetup[input.provider as ImageProviderName] || providerSetup[input.name as ImageProviderName]
+  
   input.provider = BuiltInProviders.includes(input.provider as ImageProviderName)
     ? await resolver.resolve('./runtime/providers/' + input.provider)
     : await resolvePath(input.provider)
-
-  const setup = input.setup || providerSetup[input.name as ImageProviderName]
 
   return <ImageModuleProvider> {
     ...input,


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #1414
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Because the name is user provided and can (and should be different if we have multiple instances of one provider) then any name different than the provider name (eg: `my-remote-ipx` instead of `ipx`) will not setup the provider as expected
<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
