### PR TITLE
docs: fix inconsistent spelling

### DIFF
--- a/docs/content/2.usage/1.nuxt-img.md
+++ b/docs/content/2.usage/1.nuxt-img.md
@@ -104,19 +104,19 @@ The placeholder prop can be either a string, a boolean, a number, or an array. T
 
 ```html
 <!-- Automatically generate a placeholder based on the original image -->
-<nuxt-img src="/nuxt.png" placeholder />
+<NuxtImg src="/nuxt.png" placeholder />
 
 <!-- Set a width, height for the automatically generated placeholder  -->
-<nuxt-img src="/nuxt.png" :placeholder="[50, 25]" />
+<NuxtImg src="/nuxt.png" :placeholder="[50, 25]" />
 
 <!-- Set a width, height, quality & blur for the automatically generated placeholder  -->
-<nuxt-img src="/nuxt.png" :placeholder="[50, 25, 75, 5]" />
+<NuxtImg src="/nuxt.png" :placeholder="[50, 25, 75, 5]" />
 
 <!-- Set the width & height of the automatically generated placeholder, image will be a square -->
-<nuxt-img src="/nuxt.png" :placeholder="15" />
+<NuxtImg src="/nuxt.png" :placeholder="15" />
 
 <!-- Provide your own image -->
-<nuxt-img src="/nuxt.png" placeholder="./placeholder.png" />
+<NuxtImg src="/nuxt.png" placeholder="./placeholder.png" />
 ```
 
 You can also leverage [`useImage()`](/usage/use-image) to generate a placeholder image based on the original image, can be useful if the source is an SVG or you want better control on the modifiers:
@@ -137,10 +137,10 @@ When using a placeholder, you can use `placeholder-class` to apply a class to th
 
 ```html
 <!-- Apply a static class to the original image -->
-<nuxt-img src="/nuxt.png" placeholder placeholder-class="custom" />
+<NuxtImg src="/nuxt.png" placeholder placeholder-class="custom" />
 
 <!-- Apply a dynamic class to the original image -->
-<nuxt-img src="/nuxt.png" placeholder :placeholder-class="custom" />
+<NuxtImg src="/nuxt.png" placeholder :placeholder-class="custom" />
 ```
 
 ::callout


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I noticed some variation in notation in the `<NuxtImg>` documentation.
  - https://image.nuxt.com/usage/nuxt-img

Therefore, I have standardized it from `<nuxt-img>` to `<NuxtImg>`.