### PR TITLE
feat: provide runtimeConfig to getImage function (#1247)

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -76,7 +76,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
     options.densities = options.densities || []
 
-    const imageOptions: Omit<CreateImageOptions, 'providers' | 'nuxt'> = pick(options, [
+    const imageOptions: Omit<CreateImageOptions, 'providers' | 'nuxt' | 'runtimeConfig'> = pick(options, [
       'screens',
       'presets',
       'provider',

--- a/src/runtime/composables.ts
+++ b/src/runtime/composables.ts
@@ -14,5 +14,6 @@ export const useImage = (): $Img => {
     nuxt: {
       baseURL: config.app.baseURL,
     },
+    runtimeConfig: config,
   }))
 }

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -1,3 +1,5 @@
+import type { RuntimeConfig } from '@nuxt/schema'
+
 export interface ImageModifiers {
   width: number
   height: number
@@ -45,6 +47,7 @@ export interface CreateImageOptions {
   densities: number[]
   format: string[]
   quality?: number
+  runtimeConfig: RuntimeConfig
 }
 
 export interface ImageInfo {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1247

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This change passes the runtime config to the `getImage` function of an image provider. It allows built-in or custom providers to support options that are configured at runtime rather than build time.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
