### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,3 @@
-import process from 'node:process'
-
 import { parseURL, withLeadingSlash } from 'ufo'
 import { defineNuxtModule, addTemplate, addImports, createResolver, addComponent, addPlugin } from '@nuxt/kit'
 import { resolve } from 'pathe'
@@ -60,7 +58,9 @@ export default defineNuxtModule<ModuleOptions>({
     options.dir = resolve(nuxt.options.srcDir, options.dir)
 
     // Domains from environment variable
-    const domainsFromENV = process.env.NUXT_IMAGE_DOMAINS?.replace(/\s/g, '').split(',') || []
+    const domainsFromENV = typeof import.meta.env.NUXT_IMAGE_DOMAINS === 'string'
+      ? import.meta.env.NUXT_IMAGE_DOMAINS.replace(/\s/g, '').split(',')
+      : []
 
     // Normalize domains to hostname
     options.domains = [...new Set([...options.domains, ...domainsFromENV])]

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -160,13 +160,13 @@ const autodetectableProviders: Partial<Record<ProviderName, ImageProviderName>> 
 
 const normalizableProviders: Partial<Record<string, () => ImageProviderName>> = {
   netlify: () => {
-    return process.env.NETLIFY_LFS_ORIGIN_URL ? 'netlifyLargeMedia' : 'netlifyImageCdn'
+    return import.meta.env.NETLIFY_LFS_ORIGIN_URL ? 'netlifyLargeMedia' : 'netlifyImageCdn'
   },
 }
 
 export function detectProvider(userInput: string = '') {
-  if (process.env.NUXT_IMAGE_PROVIDER) {
-    return process.env.NUXT_IMAGE_PROVIDER
+  if (typeof import.meta.env.NUXT_IMAGE_PROVIDER === 'string') {
+    return import.meta.env.NUXT_IMAGE_PROVIDER
   }
 
   if (userInput && userInput !== 'auto') {

--- a/src/runtime/components/nuxt-img.ts
+++ b/src/runtime/components/nuxt-img.ts
@@ -104,7 +104,7 @@ export default defineComponent({
     }
 
     // Prerender static images
-    if (import.meta.server && import.meta.env.prerender) {
+    if (import.meta.server && import.meta.prerender) {
       prerenderStaticImages(src.value, sizes.value.srcset)
     }
 

--- a/src/runtime/components/nuxt-img.ts
+++ b/src/runtime/components/nuxt-img.ts
@@ -104,7 +104,7 @@ export default defineComponent({
     }
 
     // Prerender static images
-    if (import.meta.server && process.env.prerender) {
+    if (import.meta.server && import.meta.env.prerender) {
       prerenderStaticImages(src.value, sizes.value.srcset)
     }
 

--- a/src/runtime/components/nuxt-picture.ts
+++ b/src/runtime/components/nuxt-picture.ts
@@ -87,7 +87,7 @@ export default defineComponent({
     const imgEl = ref<HTMLImageElement>()
 
     // Prerender static images
-    if (import.meta.server && process.env.prerender) {
+    if (import.meta.server && import.meta.env.prerender) {
       for (const src of sources.value as Source[]) {
         prerenderStaticImages(src.src, src.srcset)
       }

--- a/src/runtime/components/nuxt-picture.ts
+++ b/src/runtime/components/nuxt-picture.ts
@@ -87,7 +87,7 @@ export default defineComponent({
     const imgEl = ref<HTMLImageElement>()
 
     // Prerender static images
-    if (import.meta.server && import.meta.env.prerender) {
+    if (import.meta.server && import.meta.prerender) {
       for (const src of sources.value as Source[]) {
         prerenderStaticImages(src.src, src.srcset)
       }

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -14,7 +14,7 @@ export function createImage(globalOptions: CreateImageOptions) {
     const image = resolveImage(ctx, input, options)
 
     // Prerender static images
-    if (import.meta.server && import.meta.env.prerender) {
+    if (import.meta.server && import.meta.prerender) {
       prerenderStaticImages(image.url)
     }
 

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -14,7 +14,7 @@ export function createImage(globalOptions: CreateImageOptions) {
     const image = resolveImage(ctx, input, options)
 
     // Prerender static images
-    if (import.meta.server && process.env.prerender) {
+    if (import.meta.server && import.meta.env.prerender) {
       prerenderStaticImages(image.url)
     }
 

--- a/src/runtime/providers/awsAmplify.ts
+++ b/src/runtime/providers/awsAmplify.ts
@@ -8,18 +8,18 @@ export const getImage: ProviderGetImage = (src, { modifiers, baseURL = '/_amplif
 
   if (!width) {
     width = largestWidth
-    if (process.env.NODE_ENV === 'development') {
+    if (import.meta.env.NODE_ENV === 'development') {
       console.warn(`A defined width should be provided to use the \`awsAmplify\` provider. Defaulting to \`${largestWidth}\`. Warning originated from \`${src}\`.`)
     }
   }
   else if (!validWidths.includes(width)) {
     width = validWidths.find(validWidth => validWidth > width) || largestWidth
-    if (process.env.NODE_ENV === 'development') {
+    if (import.meta.env.NODE_ENV === 'development') {
       console.warn(`The width being used (\`${modifiers?.width}\`) should be added to \`image.screens\`. Defaulting to \`${width}\`. Warning originated from \`${src}\`.`)
     }
   }
 
-  if (process.env.NODE_ENV === 'development') {
+  if (import.meta.env.NODE_ENV === 'development') {
     return { url: src }
   }
 

--- a/src/runtime/providers/netlifyLargeMedia.ts
+++ b/src/runtime/providers/netlifyLargeMedia.ts
@@ -18,7 +18,7 @@ export const operationsGenerator = createOperationsGenerator({
   formatter: (key, value) => encodeQueryItem(key, value),
 })
 
-const isDev = process.env.NODE_ENV === 'development'
+const isDev = import.meta.env.NODE_ENV === 'development'
 
 // https://docs.netlify.com/large-media/transform-images/
 

--- a/src/runtime/providers/sanity.ts
+++ b/src/runtime/providers/sanity.ts
@@ -42,7 +42,7 @@ const operationsGenerator = createOperationsGenerator({
   formatter: (key, value) => String(value) === 'true' ? key : `${key}=${value}`,
 })
 
-const isDev = process.env.NODE_ENV === 'development'
+const isDev = import.meta.env.NODE_ENV === 'development'
 
 const getMetadata = (id: string) => {
   const result = id.match(/-(?<width>\d*)x(?<height>\d*)-(?<format>.*)$/)

--- a/src/runtime/providers/vercel.ts
+++ b/src/runtime/providers/vercel.ts
@@ -10,18 +10,18 @@ export const getImage: ProviderGetImage = (src, { modifiers, baseURL = '/_vercel
 
   if (!width) {
     width = largestWidth
-    if (process.env.NODE_ENV === 'development') {
+    if (import.meta.env.NODE_ENV === 'development') {
       console.warn(`A defined width should be provided to use the \`vercel\` provider. Defaulting to \`${largestWidth}\`. Warning originated from \`${src}\`.`)
     }
   }
   else if (!validWidths.includes(width)) {
     width = validWidths.find(validWidth => validWidth > width) || largestWidth
-    if (process.env.NODE_ENV === 'development') {
+    if (import.meta.env.NODE_ENV === 'development') {
       console.warn(`The width being used (\`${modifiers?.width}\`) should be added to \`image.screens\`. Defaulting to \`${width}\`. Warning originated from \`${src}\`.`)
     }
   }
 
-  if (process.env.NODE_ENV === 'development') {
+  if (import.meta.env.NODE_ENV === 'development') {
     return { url: src }
   }
 

--- a/src/runtime/utils/prerender.ts
+++ b/src/runtime/utils/prerender.ts
@@ -2,7 +2,7 @@ import { appendHeader } from 'h3'
 import { useRequestEvent } from '#imports'
 
 export function prerenderStaticImages(src = '', srcset = '') {
-  if (!import.meta.server || !import.meta.env.prerender) {
+  if (!import.meta.server || !import.meta.prerender) {
     return
   }
 

--- a/src/runtime/utils/prerender.ts
+++ b/src/runtime/utils/prerender.ts
@@ -2,7 +2,7 @@ import { appendHeader } from 'h3'
 import { useRequestEvent } from '#imports'
 
 export function prerenderStaticImages(src = '', srcset = '') {
-  if (!import.meta.server || !process.env.prerender) {
+  if (!import.meta.server || !import.meta.env.prerender) {
     return
   }
 


### PR DESCRIPTION
Continuation of https://github.com/nuxt/image/pull/1301 addressing remaining occurences of `process.*`/`process.env.*`.