### PR TITLE
fix(weserv): map rotate operation to `ro`

### DIFF
--- a/src/runtime/providers/weserv.ts
+++ b/src/runtime/providers/weserv.ts
@@ -21,7 +21,7 @@ const operationsGenerator = createOperationsGenerator({
     contrast: 'con',
     blur: 'blur',
     mirror: 'flop',
-    rotate: 'rot',
+    rotate: 'ro',
     mask: 'mask',
     maskTrim: 'mtrim',
     maskBackground: 'mbg',


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/image/issues/1408

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Rotation operator should be mapped to `ro` instead of `rot`, as per [docs](https://wsrv.nl/docs/orientation.html#rotation).
