### PR TITLE
fix: prevent hydration mismatch in `<NuxtImg>`

### DIFF
--- a/src/runtime/components/NuxtImg.vue
+++ b/src/runtime/components/NuxtImg.vue
@@ -4,7 +4,7 @@
     :class="props.placeholder && !placeholderLoaded ? props.placeholderClass : undefined"
     v-bind="{
       ...isServer ? { onerror: 'this.setAttribute(\'data-error\', 1)' } : {},
-      ..._attrs,
+      ...imgAttrs,
       ...attrs,
     }"
     :src="src"
@@ -56,7 +56,7 @@ const sizes = computed(() => $img.getSizes(props.src!, {
   },
 }))
 
-const _attrs = computed(() => {
+const imgAttrs = computed(() => {
   const attrs: AttrsT = { ..._base.attrs.value, 'data-nuxt-img': '' }
 
   if (!props.placeholder || placeholderLoaded.value) {


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/image/issues/1443

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Renames `_attrs` to `imgAttrs` in `<NuxtImg>` component.
