### PR TITLE
fix(vercel): added missing `formats` config & improved documentation

### DIFF
--- a/docs/content/3.providers/vercel.md
+++ b/docs/content/3.providers/vercel.md
@@ -12,6 +12,10 @@ When deploying your nuxt applications to [Vercel](https://vercel.com/) platform,
 
 This provider will be enabled by default in vercel deployments.
 
+::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
+Vercel requires you to explicitly list all the widths used in your app. [See example below.](#sizes)
+::
+
 ## Domains
 
 To use external URLs (images not in `public/` directory), hostnames should be whitelisted.
@@ -30,19 +34,33 @@ export default {
 
 ## Sizes
 
-Specify any custom `width` property you use in `<NuxtImg>`, `<NuxtPicture>` and `$img`.
+You need to specify **every custom width** used in `<NuxtImg>`, `<NuxtPicture>` or `$img` for vercel to resize them properly. [Source.](https://vercel.com/docs/build-output-api/v3/configuration#api)
 
 If a width is not defined, image will fallback to the next bigger width.
 
+::callout{icon="i-heroicons-light-bulb"}
+Don't forget to also take into account [`densities`](/get-started/configuration#densities).
+::
+
 **Example:**
 
-```ts [nuxt.config]
-export default {
-  image: {
-    screens: {
-      icon: 40,
-      avatar: 24
+::code-group
+
+  ```html [index.vue]
+  <template>
+    <NuxtImg height="40" width="40" preset="cover" src="/nuxt-icon.png" />
+  </template>
+  ```
+
+  ```ts [nuxt.config]
+  export default {
+    image: {
+      screens: {
+        icon: 40,
+        icon2x: 80
+      }
     }
   }
-}
-```
+  ```
+
+::

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -56,7 +56,7 @@ export const providerSetup: Partial<Record<ImageProviderName, ProviderSetup>> = 
   ipx: ipxSetup(),
   ipxStatic: ipxSetup({ isStatic: true }),
 
-  // https://vercel.com/docs/more/adding-your-framework#images
+  // https://vercel.com/docs/build-output-api/v3/configuration#images
   vercel(_providerOptions, moduleOptions, nuxt: Nuxt) {
     nuxt.options.nitro = defu(nuxt.options.nitro, {
       vercel: {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -65,6 +65,7 @@ export const providerSetup: Partial<Record<ImageProviderName, ProviderSetup>> = 
             domains: moduleOptions.domains,
             minimumCacheTTL: 60 * 5,
             sizes: Array.from(new Set(Object.values(moduleOptions.screens || {}))),
+            formats: ['image/webp', 'image/avif'],
           },
         },
       } satisfies NitroConfig['vercel'],

--- a/src/runtime/providers/vercel.ts
+++ b/src/runtime/providers/vercel.ts
@@ -1,7 +1,7 @@
 import { stringifyQuery } from 'ufo'
 import type { ProviderGetImage } from '../../module'
 
-// https://vercel.com/docs/more/adding-your-framework#images
+// https://vercel.com/docs/build-output-api/v3/configuration#images
 
 export const getImage: ProviderGetImage = (src, { modifiers, baseURL = '/_vercel/image' } = {}, ctx) => {
   const validWidths = Object.values(ctx.options.screens || {}).sort((a, b) => a - b)


### PR DESCRIPTION
### 🔗 Linked issue

Fix #1490
Fix #1455
Fix #1107
Closes https://github.com/nuxt/image/pull/1181

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

- Added the missing `formats` in nitro Vercel config & updated docs to avoid missing the fact that every custom sizes need to be specified using Vercel image optimizer.
- Without `formats`, Vercel does not resize images.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
