### PR TITLE
docs: improve cloudflare provider page

### DIFF
--- a/docs/content/3.providers/cloudflare.md
+++ b/docs/content/3.providers/cloudflare.md
@@ -10,6 +10,10 @@ links:
 
 Integration between [Cloudflare](https://developers.cloudflare.com/images/) and the image module.
 
+::callout{icon="i-heroicons-exclamation-triangle" color="amber"}
+Before using this provider, make sure to enable **Image Transformations** for your domain in the Cloudflare dashboard at `Images > Transformations`. If you plan to use images from external domains, also enable "Resize Image from Any Origin".
+::
+
 To use this provider you just need to specify the base url (zone) of your service:
 
 ```ts [nuxt.config.ts]


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/image/issues/1546 and https://github.com/nuxt/image/issues/805.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The documentation for Cloudflare is missing an important step, which is to enable image transformations for the deployment URL at Cloudflare dashboard. Otherwise, the module does not work and it causes a lot of confusion for initial setup. This PR aims to clarify this with a warning callout.
