### PR TITLE
fix: set up non-default `ipx` providers if `options.ipx` is set

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -134,13 +134,20 @@ ${providers.map(p => `  ['${p.name}']: { provider: ${p.importName}, defaults: ${
     })
 
     nuxt.hook('nitro:init', async (nitro) => {
-      if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic' || 'ipx' in options || 'ipxStatic' in options) {
+      if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic' || 'ipx' in options) {
         const resolvedProvider = nitro.options.static || options.provider === 'ipxStatic'
           ? 'ipxStatic'
           : nitro.options.node ? 'ipx' : 'none'
 
-        imageOptions.provider = options.provider ||= resolvedProvider
-        options[resolvedProvider] = options[resolvedProvider] || {}
+        if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic') {
+          imageOptions.provider = options.provider = resolvedProvider
+          options[resolvedProvider] = options[resolvedProvider] || {}
+        }
+
+        // handle the case of `ipx: {}` existing in options, but deploying a static site
+        if (resolvedProvider === 'ipxStatic' && options.provider !== resolvedProvider) {
+          options.ipxStatic ||= options.ipx
+        }
 
         const p = await resolveProvider(nuxt, resolvedProvider, {
           options: options[resolvedProvider],

--- a/src/module.ts
+++ b/src/module.ts
@@ -141,12 +141,15 @@ ${providers.map(p => `  ['${p.name}']: { provider: ${p.importName}, defaults: ${
 
         if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic') {
           imageOptions.provider = options.provider = resolvedProvider
-          options[resolvedProvider] = options[resolvedProvider] || {}
         }
 
-        // handle the case of `ipx: {}` existing in options, but deploying a static site
-        if (resolvedProvider === 'ipxStatic' && options.provider !== resolvedProvider) {
-          options.ipxStatic ||= options.ipx
+        // initialise provider options
+        if (resolvedProvider === 'ipxStatic') {
+          // handle the case of `ipx: {}` existing in options, but deploying a static site
+          options.ipxStatic ||= options.ipx || {}
+        }
+        else {
+          options[resolvedProvider] = options[resolvedProvider] || {}
         }
 
         const p = await resolveProvider(nuxt, resolvedProvider, {

--- a/src/module.ts
+++ b/src/module.ts
@@ -134,12 +134,12 @@ ${providers.map(p => `  ['${p.name}']: { provider: ${p.importName}, defaults: ${
     })
 
     nuxt.hook('nitro:init', async (nitro) => {
-      if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic') {
+      if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic' || 'ipx' in options || 'ipxStatic' in options) {
         const resolvedProvider = nitro.options.static || options.provider === 'ipxStatic'
           ? 'ipxStatic'
           : nitro.options.node ? 'ipx' : 'none'
 
-        imageOptions.provider = options.provider = resolvedProvider
+        imageOptions.provider = options.provider || resolvedProvider
         options[resolvedProvider] = options[resolvedProvider] || {}
 
         const p = await resolveProvider(nuxt, resolvedProvider, {

--- a/src/module.ts
+++ b/src/module.ts
@@ -139,7 +139,7 @@ ${providers.map(p => `  ['${p.name}']: { provider: ${p.importName}, defaults: ${
           ? 'ipxStatic'
           : nitro.options.node ? 'ipx' : 'none'
 
-        imageOptions.provider = options.provider || resolvedProvider
+        imageOptions.provider = options.provider ||= resolvedProvider
         options[resolvedProvider] = options[resolvedProvider] || {}
 
         const p = await resolveProvider(nuxt, resolvedProvider, {

--- a/src/module.ts
+++ b/src/module.ts
@@ -134,7 +134,7 @@ ${providers.map(p => `  ['${p.name}']: { provider: ${p.importName}, defaults: ${
     })
 
     nuxt.hook('nitro:init', async (nitro) => {
-      if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic' || 'ipx' in options) {
+      if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic' || options.ipx) {
         const resolvedProvider = nitro.options.static || options.provider === 'ipxStatic'
           ? 'ipxStatic'
           : nitro.options.node ? 'ipx' : 'none'


### PR DESCRIPTION
Fixes #1414

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Previously, specifying a custom provider would prevent setup of ipx, which happens in a `'nitro:init` hook. That is, there was no way use ipx if it wasn't your default provider.

Now, you just need to add `ipx` to the image options:

```
image: {
  ipx: {},
  provider: "yourprovider",
  providers: {
    yourprovider: { ... }
  }
}
```

