### PR TITLE
docs-#1020: add nuxt img alt prop definition

### DIFF
--- a/docs/content/2.usage/1.nuxt-img.md
+++ b/docs/content/2.usage/1.nuxt-img.md
@@ -56,6 +56,20 @@ Specify width/height of the image.
 - Use desired width/height for static sized images like icons or avatars
 - Use original image width/height for responsive images (when using [`sizes`](#sizes))
 
+### `alt`
+
+Specifies an alternate text for an image, if the image cannot be displayed.
+
+- The text should describe the image if the image contains information
+- The text should explain where the link goes if the image is inside an <a> element
+- Use alt="" if the image is only for decoration
+
+```html
+<NuxtImg src="/nuxt.png" alt="My image file description" />
+```
+
+For image optimization when using external urls in `src`, we need to whitelist them using [`domains`](/get-started/configuration#domains) option.
+
 ### `sizes`
 
 Specify responsive sizes.


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Resolves #1020 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a note in the documentation about the `alt` prop that `NuxtImg` accepts while it is not documented.
