### PR TITLE
fix: emit error events from `<NuxtImg>` placeholder

### DIFF
--- a/src/runtime/components/NuxtImg.vue
+++ b/src/runtime/components/NuxtImg.vue
@@ -152,6 +152,10 @@ onMounted(() => {
       emit('load', event)
     }
 
+    img.onerror = (event) => {
+      emit('error', event)
+    }
+
     markFeatureUsage('nuxt-image')
 
     return

--- a/test/unit/image.test.ts
+++ b/test/unit/image.test.ts
@@ -160,15 +160,20 @@ describe('Renders simple image', () => {
 
 const getImageLoad = (cb = () => {}) => {
   let resolve = () => {}
+  let reject = () => {}
   let image = {} as HTMLImageElement
   const loadEvent = Symbol('loadEvent')
+  const errorEvent = Symbol('errorEvent')
   const ImageMock = vi.fn(() => {
     const _image = {
       onload: () => {},
+      onerror: () => {},
     } as unknown as HTMLImageElement
     image = _image
     // @ts-expect-error not valid argument for onload
     resolve = () => _image.onload?.(loadEvent)
+    // @ts-expect-error not valid argument for onload
+    reject = () => _image.onerror?.(errorEvent)
 
     return _image
   })
@@ -179,8 +184,10 @@ const getImageLoad = (cb = () => {}) => {
 
   return {
     resolve,
+    reject,
     image,
     loadEvent,
+    errorEvent,
   }
 }
 
@@ -279,6 +286,26 @@ describe('Renders placeholder image', () => {
       ]
     `)
     expect(wrapper.element.getAttribute('src')).toMatchInlineSnapshot(`"/_ipx/_/image.png"`)
+  })
+
+  it('props.placeholder with source loaded error event triggers', async () => {
+    const {
+      reject: rejectImage,
+      errorEvent,
+    } = getImageLoad(() => {
+      wrapper = mount(NuxtImg, {
+        propsData: {
+          width: 200,
+          height: 200,
+          src,
+          placeholder: true,
+        },
+      })
+    })
+    rejectImage()
+    await nextTick()
+
+    expect(wrapper.emitted().error![0]).toStrictEqual([errorEvent])
   })
 })
 


### PR DESCRIPTION
resolves #1639 

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I need to deal with the ERROR event when the picture is loaded, but if I use the Placehoder attribute at the same time, the ERROR event will not be thrown out

```javascript
onMounted(() => {
  if (placeholder.value) {
    const img = new Image()

    if (mainSrc.value) {
      img.src = mainSrc.value
    }

    if (props.sizes) {
      img.sizes = sizes.value.sizes || ''
      img.srcset = sizes.value.srcset
    }
    // !!! Here, if the IMG loading error, there is no ERROR incident !!!
    img.onload = (event) => {
      placeholderLoaded.value = true
      emit('load', event)
    }
    // add this to fix
    img.onerror = (event) => {
      emit('error', event)
    }

    markFeatureUsage('nuxt-image')

    return
  }
  // ...other
}
```
