### PR TITLE
fix: double loading image when placeholder is present

### DIFF
--- a/src/runtime/components/NuxtImg.vue
+++ b/src/runtime/components/NuxtImg.vue
@@ -150,7 +150,7 @@ const nuxtApp = useNuxtApp()
 const initialLoad = nuxtApp.isHydrating
 
 onMounted(() => {
-  if (placeholder.value || props.custom) {
+  if (props.custom) {
     const img = new Image()
 
     if (mainSrc.value) {
@@ -185,11 +185,14 @@ onMounted(() => {
       emit('error', new Event('error'))
     }
     else {
+      placeholderLoaded.value = true
       emit('load', new Event('load'))
     }
+    return
   }
 
   imgEl.value.onload = (event) => {
+    placeholderLoaded.value = true
     emit('load', event)
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1683

### ❓ fix

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We resolved an issue where images could load more than once in the NuxtImg component. Previously, when a placeholder image was in use, it triggered a new image load even though the main image had already started loading. The update ensures that if a placeholder is already handled, we avoid loading the image again. This change prevents duplicate network requests and avoids unnecessary load events