### PR TITLE
docs: fix confusing typo in 1.nuxt-img.md

### DIFF
--- a/docs/content/2.usage/1.nuxt-img.md
+++ b/docs/content/2.usage/1.nuxt-img.md
@@ -183,7 +183,7 @@ You can also leverage [`useImage()`](/usage/use-image) to generate a placeholder
 ```vue
 <template>
   <NuxtImg
-    src="/nuxt.svg`"
+    src="/nuxt.svg"
     :placeholder="img(`/nuxt.svg`, { h: 10, f: 'png', blur: 2, q: 50 })"
   />
 </template>


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

Just fixed a typo that caused confusion, as the code did not work as described.
No other typos were found to batch-fix.
