### PR TITLE
fix(cloudflare): don't add baseURL if no operations

### DIFF
--- a/src/runtime/providers/cloudflare.ts
+++ b/src/runtime/providers/cloudflare.ts
@@ -41,7 +41,7 @@ export const getImage: ProviderGetImage = (src, {
   const operations = operationsGenerator(mergeModifiers as any)
 
   // https://<ZONE>/cdn-cgi/image/<OPTIONS>/<SOURCE-IMAGE>
-  const url = operations ? joinURL(baseURL, 'cdn-cgi/image', operations, src) : joinURL(baseURL, src)
+  const url = operations ? joinURL(baseURL, 'cdn-cgi/image', operations, src) : src
 
   return {
     url,


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Should resolves #1080

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Using Cloudflare means setting the baseURL as a domain.

But if no modifiers/operations are set, it will join the urls, making it fail when the source is an absolute url.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
