### PR TITLE
fix(ipx): always use `ipx` provider if external `baseURL` is provided

### DIFF
--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -4,6 +4,7 @@ import { useNuxt, createResolver, useNitro } from '@nuxt/kit'
 import type { NitroEventHandler } from 'nitropack'
 import type { HTTPStorageOptions, NodeFSSOptions, IPXOptions } from 'ipx'
 import { defu } from 'defu'
+import { hasProtocol } from 'ufo'
 import type { ProviderSetup } from './types'
 
 export type IPXRuntimeConfig = Omit<IPXOptions, 'storage' | 'httpStorage'> & { http: HTTPStorageOptions, fs: NodeFSSOptions } & {
@@ -20,9 +21,10 @@ export const ipxSetup: IPXSetupT = setupOptions => (providerOptions, moduleOptio
   const ipxBaseURL = providerOptions.options?.baseURL || '/_ipx'
 
   // Avoid overriding user custom handler
-  const hasUserProvidedIPX
-    = nuxt.options.serverHandlers.find(handler => handler.route?.startsWith(ipxBaseURL))
-      || nuxt.options.devServerHandlers.find(handler => handler.route?.startsWith(ipxBaseURL))
+  const hasUserProvidedIPX = nuxt.options.serverHandlers.find(handler => handler.route?.startsWith(ipxBaseURL))
+    || nuxt.options.devServerHandlers.find(handler => handler.route?.startsWith(ipxBaseURL))
+    || hasProtocol(ipxBaseURL, { acceptRelative: true })
+
   if (hasUserProvidedIPX) {
     return
   }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,6 @@
 import process from 'node:process'
 
-import { parseURL, withLeadingSlash } from 'ufo'
+import { hasProtocol, parseURL, withLeadingSlash } from 'ufo'
 import { defineNuxtModule, addTemplate, addImports, addServerImports, createResolver, addComponent, addPlugin, addServerTemplate } from '@nuxt/kit'
 import { resolve } from 'pathe'
 import { resolveProviders, detectProvider, resolveProvider } from './provider'
@@ -141,9 +141,12 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.hook('nitro:init', async (nitro) => {
       if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic' || options.ipx) {
-        const resolvedProvider = nitro.options.static || options.provider === 'ipxStatic'
-          ? 'ipxStatic'
-          : nitro.options.node ? 'ipx' : 'none'
+        const hasExternalIPX = (options.ipx?.baseURL && hasProtocol(options.ipx.baseURL, { acceptRelative: true }))
+        const resolvedProvider = hasExternalIPX
+          ? 'ipx'
+          : nitro.options.static || options.provider === 'ipxStatic'
+            ? 'ipxStatic'
+            : nitro.options.node ? 'ipx' : 'none'
 
         if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic') {
           imageOptions.provider = options.provider = resolvedProvider


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

it's possible to use a self-hosted ipx instance and in this case we don't need to add an `/_ipx` handler. And we can support ipx even on non-node targets.

in such a case, this PR avoids setting up the handler and doesn't disable ipx outside a node environment.