### PR TITLE
fix(ipxStatic): strip repeated slashes from image path

### DIFF
--- a/src/runtime/providers/ipx.ts
+++ b/src/runtime/providers/ipx.ts
@@ -2,7 +2,7 @@ import { joinURL, encodePath, encodeParam } from 'ufo'
 import type { ProviderGetImage } from '../../module'
 import { createOperationsGenerator } from '#image'
 
-const operationsGenerator = createOperationsGenerator({
+export const operationsGenerator = createOperationsGenerator({
   keyMap: {
     format: 'f',
     fit: 'fit',

--- a/src/runtime/providers/ipxStatic.ts
+++ b/src/runtime/providers/ipxStatic.ts
@@ -1,1 +1,38 @@
-export * from './ipx'
+import { joinURL, encodePath, encodeParam } from 'ufo'
+import type { ProviderGetImage } from '../../module'
+import { createOperationsGenerator } from '#image'
+
+const operationsGenerator = createOperationsGenerator({
+  keyMap: {
+    format: 'f',
+    fit: 'fit',
+    width: 'w',
+    height: 'h',
+    resize: 's',
+    quality: 'q',
+    background: 'b',
+  },
+  joinWith: '&',
+  formatter: (key, val) => encodeParam(key) + '_' + encodeParam(val),
+})
+
+export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL } = {}, ctx) => {
+  if (modifiers.width && modifiers.height) {
+    modifiers.resize = `${modifiers.width}x${modifiers.height}`
+    delete modifiers.width
+    delete modifiers.height
+  }
+
+  const params = operationsGenerator(modifiers) || '_'
+
+  if (!baseURL) {
+    baseURL = joinURL(ctx.options.nuxt.baseURL, '/_ipx')
+  }
+
+  return {
+    url: joinURL(baseURL, params, encodePath(src).replace(/\/{2,}/g, '/')),
+  }
+}
+
+export const validateDomains = true
+export const supportsAlias = true

--- a/src/runtime/providers/ipxStatic.ts
+++ b/src/runtime/providers/ipxStatic.ts
@@ -1,20 +1,6 @@
-import { joinURL, encodePath, encodeParam } from 'ufo'
+import { joinURL, encodePath } from 'ufo'
 import type { ProviderGetImage } from '../../module'
-import { createOperationsGenerator } from '#image'
-
-const operationsGenerator = createOperationsGenerator({
-  keyMap: {
-    format: 'f',
-    fit: 'fit',
-    width: 'w',
-    height: 'h',
-    resize: 's',
-    quality: 'q',
-    background: 'b',
-  },
-  joinWith: '&',
-  formatter: (key, val) => encodeParam(key) + '_' + encodeParam(val),
-})
+import { operationsGenerator } from './ipx'
 
 export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL } = {}, ctx) => {
   if (modifiers.width && modifiers.height) {
@@ -34,5 +20,4 @@ export const getImage: ProviderGetImage = (src, { modifiers = {}, baseURL } = {}
   }
 }
 
-export const validateDomains = true
-export const supportsAlias = true
+export { validateDomains, supportsAlias } from './ipx'


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

when using ipx in a static deployment, double slashes can lead to 404s on some providers. (this occurs when transforming images on external domains). we can solve by stripping them.

context: https://github.com/danielroe/roe.dev/blob/7704f70db1c756f28f557bd13875a29b11419ef7