### PR TITLE
feat(ipx): log the architecture of the build

### DIFF
--- a/src/ipx.ts
+++ b/src/ipx.ts
@@ -77,12 +77,17 @@ export const ipxSetup: IPXSetupT = setupOptions => (providerOptions, moduleOptio
   }
 
   if (!nuxt.options.dev && !setupOptions?.isStatic) {
-    nuxt.hooks.hook('close', async () => {
+    nitro.hooks.hook('compiled', async () => {
       const logger = useLogger('@nuxt/image')
       const target = `${platform}-${arch}`
-      logger.info(`\`sharp\` binaries have been included in your build for \`${target}\`. Make sure you deploy to the same architecture.`)
       const tracedFiles = await readdir(join(nitro.options.output.serverDir, 'node_modules/@img')).catch(() => [])
-      logger.debug(` - dependencies traced: ${tracedFiles.map(f => `@img/${f}`).join(', ')}`)
+      if (!tracedFiles.length) {
+        logger.warn(`\`sharp\` binaries for \`${target}\` cannot be found. Please report this as a bug with a reproduction at \`https://github.com/nuxt/image\`.`)
+      }
+      else {
+        logger.info(`\`sharp\` binaries have been included in your build for \`${target}\`. Make sure you deploy to the same architecture.`)
+        logger.debug(` - dependencies traced: ${tracedFiles.map(f => `@img/${f}`).join(', ')}`)
+      }
     })
   }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,8 +1,10 @@
 import process from 'node:process'
+import { arch, platform } from 'node:os'
+import { readdir } from 'node:fs/promises'
 
 import { hasProtocol, parseURL, withLeadingSlash } from 'ufo'
-import { defineNuxtModule, addTemplate, addImports, addServerImports, createResolver, addComponent, addPlugin, addServerTemplate } from '@nuxt/kit'
-import { resolve } from 'pathe'
+import { defineNuxtModule, addTemplate, addImports, addServerImports, createResolver, addComponent, addPlugin, addServerTemplate, useLogger } from '@nuxt/kit'
+import { join, resolve } from 'pathe'
 import { resolveProviders, detectProvider, resolveProvider } from './provider'
 import type { ImageProviders, ImageOptions, InputProvider, CreateImageOptions, ImageModuleProvider } from './types'
 
@@ -147,6 +149,16 @@ export default defineNuxtModule<ModuleOptions>({
           : nitro.options.static || options.provider === 'ipxStatic'
             ? 'ipxStatic'
             : nitro.options.node ? 'ipx' : 'none'
+
+        if (!nuxt.options.dev && (options.provider === 'ipx' || options.provider === 'ipxStatic' || options.ipx)) {
+          nuxt.hooks.hook('close', async () => {
+            const logger = useLogger('@nuxt/image')
+            const target = `${platform}-${arch}`
+            logger.info(`\`sharp\` binaries have been included in your build for \`${target}\`. Make sure you deploy to the same architecture.`)
+            const tracedFiles = await readdir(join(nitro.options.output.serverDir, 'node_modules/@img')).catch(() => [])
+            logger.debug(` - dependencies traced: ${tracedFiles.map(f => `@img/${f}`).join(', ')}`)
+          })
+        }
 
         if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic') {
           imageOptions.provider = options.provider = resolvedProvider

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,10 +1,8 @@
 import process from 'node:process'
-import { arch, platform } from 'node:os'
-import { readdir } from 'node:fs/promises'
 
 import { hasProtocol, parseURL, withLeadingSlash } from 'ufo'
-import { defineNuxtModule, addTemplate, addImports, addServerImports, createResolver, addComponent, addPlugin, addServerTemplate, useLogger } from '@nuxt/kit'
-import { join, resolve } from 'pathe'
+import { defineNuxtModule, addTemplate, addImports, addServerImports, createResolver, addComponent, addPlugin, addServerTemplate } from '@nuxt/kit'
+import { resolve } from 'pathe'
 import { resolveProviders, detectProvider, resolveProvider } from './provider'
 import type { ImageProviders, ImageOptions, InputProvider, CreateImageOptions, ImageModuleProvider } from './types'
 
@@ -149,16 +147,6 @@ export default defineNuxtModule<ModuleOptions>({
           : nitro.options.static || options.provider === 'ipxStatic'
             ? 'ipxStatic'
             : nitro.options.node ? 'ipx' : 'none'
-
-        if (!nuxt.options.dev && (options.provider === 'ipx' || options.provider === 'ipxStatic' || options.ipx)) {
-          nuxt.hooks.hook('close', async () => {
-            const logger = useLogger('@nuxt/image')
-            const target = `${platform}-${arch}`
-            logger.info(`\`sharp\` binaries have been included in your build for \`${target}\`. Make sure you deploy to the same architecture.`)
-            const tracedFiles = await readdir(join(nitro.options.output.serverDir, 'node_modules/@img')).catch(() => [])
-            logger.debug(` - dependencies traced: ${tracedFiles.map(f => `@img/${f}`).join(', ')}`)
-          })
-        }
 
         if (!options.provider || options.provider === 'ipx' || options.provider === 'ipxStatic') {
           imageOptions.provider = options.provider = resolvedProvider


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With upcoming release of nuxt image including ipx v3, it's important to let users know the architecture they have built for.

This adds a log after the build is complete.

![CleanShot 2025-04-08 at 09 38 23@2x](https://github.com/user-attachments/assets/6af36c81-82b6-412d-b356-339c7d7672f2)

questions:
1. is it that important? we could move it earlier in the build pipeline rather than making sure it's the last thing users see
2. do we need to do more than add this log? the main thing is that it's there for is to help users debugging issues they might face
