### PR TITLE
docs: fix link to runtime/providers (dev -> main)

### DIFF
--- a/docs/content/4.advanced/1.custom-provider.md
+++ b/docs/content/4.advanced/1.custom-provider.md
@@ -66,7 +66,7 @@ export default defineNuxtConfig({
 })
 ```
 
-There are plenty of useful utilities that can be used to write providers by importing from `#image`. See [src/runtime/providers](https://github.com/nuxt/image/tree/dev/src/runtime/providers) for more info.
+There are plenty of useful utilities that can be used to write providers by importing from `#image`. See [src/runtime/providers](https://github.com/nuxt/image/tree/main/src/runtime/providers) for more info.
 
 ### Usage 
 Set attribute `provider` as your custom provider name. 


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

updated github link in documentation to use the correct `main` branch instead of `dev` for the providers directory.