### PR TITLE
Fix #1850

### DIFF
--- a/src/runtime/components/NuxtImg.vue
+++ b/src/runtime/components/NuxtImg.vue
@@ -104,20 +104,16 @@ const mainSrc = computed(() =>
 const src = computed(() => placeholder.value || mainSrc.value)
 
 if (import.meta.server && props.preload) {
-  const isResponsive = Object.values(sizes.value).every(v => v)
+  const hasMultipleDensities = sizes.value.srcset.includes("x, ")
 
   useHead({
     link: [{
       rel: 'preload',
       as: 'image',
       nonce: props.nonce,
-      ...(!isResponsive
-        ? { href: src.value }
-        : {
-            href: sizes.value.src,
-            imagesizes: sizes.value.sizes,
-            imagesrcset: sizes.value.srcset,
-          }),
+      href: sizes.value.src,
+      ...(sizes.value.sizes && { imagesizes: sizes.value.sizes }),
+      ...(hasMultipleDensities && { imagesrcset: sizes.value.srcset }),
       ...(typeof props.preload !== 'boolean' && props.preload.fetchPriority
         ? { fetchpriority: props.preload.fetchPriority }
         : {}),


### PR DESCRIPTION
NuxtImg did not add correct preload links for images that had multiple densities but only one size which caused the preload tag to load 1x images for devices with 2x pixel ratio. That is now fixed.

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

Resolves #1850

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Do not require both sizes and densities to be set to generate `imagesrcset`. Take each of them into account.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
