### PR TITLE
chore: prefer `nuxt` over `nuxi`

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
   ],
   "scripts": {
     "build": "nuxt-module-build build",
-    "dev": "nuxi dev playground",
-    "dev:build": "nuxi build playground",
-    "dev:generate": "nuxi generate playground",
-    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare docs",
+    "dev": "nuxt dev playground",
+    "dev:build": "nuxt build playground",
+    "dev:generate": "nuxt generate playground",
+    "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxt prepare docs",
     "docs:build": "cd docs && nuxt generate",
     "docs:dev": "pnpm nuxt dev docs",
     "lint": "eslint .",
     "prepack": "pnpm build",
     "release": "pnpm test && pnpm build && changelogen --release --push && npm publish",
-    "test": "nuxi prepare playground && pnpm vitest run --coverage",
-    "test:types": "vue-tsc --noEmit && nuxi typecheck playground && nuxi typecheck example"
+    "test": "nuxt prepare playground && pnpm vitest run --coverage",
+    "test:types": "vue-tsc --noEmit && nuxt typecheck playground && nuxt typecheck example"
   },
   "dependencies": {
     "@nuxt/kit": "^3.17.4",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

this follows up on https://github.com/nuxt/nuxt/pull/32237 to use `nuxt` command consistently now that we no longer need compatibility with nuxt 2.