### PR TITLE
fix(NuxtImg): add image onerror handler in internal script to avoid s…

### DIFF
--- a/src/runtime/components/NuxtImg.vue
+++ b/src/runtime/components/NuxtImg.vue
@@ -63,7 +63,6 @@ const imgAttrs = computed(() => ({
   ...(!props.placeholder || placeholderLoaded.value)
     ? { sizes: sizes.value.sizes, srcset: sizes.value.srcset }
     : {},
-  ...import.meta.server ? { onerror: 'this.setAttribute(\'data-error\', 1)' } : {},
   ...attrs,
 }))
 
@@ -133,6 +132,10 @@ if (import.meta.server && import.meta.prerender) {
 const initialLoad = useNuxtApp().isHydrating
 const imgEl = useTemplateRef('imgEl')
 onMounted(() => {
+  if (imgEl.value) {
+    imgEl.value.addEventListener('error', handleImgError)
+  }
+
   if (placeholder.value || props.custom) {
     const img = new Image()
 
@@ -180,6 +183,10 @@ onMounted(() => {
     emit('error', event)
   }
 })
+
+function handleImgError() {
+  this.setAttribute('data-error', '1')
+}
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
…cript-src-attr CSP violation

### 🔗 Linked issue

Resolves #1011

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The CSP header "script-src-attr" prevents inline javascript from executing when the header's value is set to 'none'. By adding the error event handler in the onMounted hook, it becomes easier for Nuxt Security to add a hash to the script and allow the error handler to execute.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
