### PR TITLE
feat!: remove `xs` and `xxl` screen sizes

### DIFF
--- a/docs/content/1.get-started/2.configuration.md
+++ b/docs/content/1.get-started/2.configuration.md
@@ -66,12 +66,10 @@ export default defineNuxtConfig({
   image: {
     // The screen sizes predefined by `@nuxt/image`:
     screens: {
-      xs: 320,
-      sm: 640,
-      md: 768,
-      lg: 1024,
-      xl: 1280,
-      xxl: 1536,
+      'sm': 640,
+      'md': 768,
+      'lg': 1024,
+      'xl': 1280,
       '2xl': 1536
     }
   }
@@ -79,7 +77,7 @@ export default defineNuxtConfig({
 ```
 
 ::callout
-We share the same naming and sizes as [Tailwind CSS](https://tailwindcss.com/docs/responsive-design), with the addition of `xs` and `xxl` (for backwards compatibility).
+By default, we share the same naming and sizes as [Tailwind CSS](https://tailwindcss.com/docs/responsive-design). If you need a list of screen sizes matching a different framework, check out [VueUse breakpoint presets](https://vueuse.org/core/useBreakpoints/#presets).
 ::
 
 ## `domains`

--- a/docs/content/2.usage/3.use-image.md
+++ b/docs/content/2.usage/3.use-image.md
@@ -85,7 +85,7 @@ const img = useImage()
 
 const _srcset = computed(() => {
   return img.getSizes(props.src, {
-    sizes: 'xs:100vw sm:100vw md:100vw lg:100vw xl:100vw',
+    sizes: 'sm:100vw md:100vw lg:100vw xl:100vw',
     modifiers: {
       format: 'webp',
       quality: 70,

--- a/src/module.ts
+++ b/src/module.ts
@@ -34,12 +34,10 @@ export default defineNuxtModule<ModuleOptions>({
     format: ['webp'],
     // https://tailwindcss.com/docs/breakpoints
     screens: {
-      'xs': 320,
       'sm': 640,
       'md': 768,
       'lg': 1024,
       'xl': 1280,
-      'xxl': 1536,
       '2xl': 1536,
     },
     providers: {},

--- a/test/unit/image.test.ts
+++ b/test/unit/image.test.ts
@@ -130,9 +130,9 @@ describe('Renders simple image', () => {
       src: '/image.png',
       width: 1000,
       height: 2000,
-      sizes: 'xs:100vw sm:100vw md:300px lg:350px xl:350px 2xl:350px',
+      sizes: 'sm:100vw md:300px lg:350px xl:350px 2xl:350px',
     })
-    expect(img.html()).toMatchInlineSnapshot(`"<img width="1000" height="2000" data-nuxt-img="" sizes="(max-width: 640px) 100vw, (max-width: 768px) 100vw, (max-width: 1024px) 300px, (max-width: 1280px) 350px, (max-width: 1536px) 350px, 350px" srcset="/_ipx/s_300x600/image.png 300w, /_ipx/s_320x640/image.png 320w, /_ipx/s_350x700/image.png 350w, /_ipx/s_600x1200/image.png 600w, /_ipx/s_640x1280/image.png 640w, /_ipx/s_700x1400/image.png 700w, /_ipx/s_1280x2560/image.png 1280w" src="/_ipx/s_1280x2560/image.png">"`)
+    expect(img.html()).toMatchInlineSnapshot(`"<img width="1000" height="2000" data-nuxt-img="" sizes="(max-width: 768px) 100vw, (max-width: 1024px) 300px, (max-width: 1280px) 350px, (max-width: 1536px) 350px, 350px" srcset="/_ipx/s_300x600/image.png 300w, /_ipx/s_320x640/image.png 320w, /_ipx/s_350x700/image.png 350w, /_ipx/s_600x1200/image.png 600w, /_ipx/s_640x1280/image.png 640w, /_ipx/s_700x1400/image.png 700w, /_ipx/s_1280x2560/image.png 1280w" src="/_ipx/s_1280x2560/image.png">"`)
   })
 
   it('without sizes, but densities', () => {

--- a/test/unit/providers.test.ts
+++ b/test/unit/providers.test.ts
@@ -39,12 +39,10 @@ import * as hygraph from '#image/providers/hygraph'
 const emptyContext = {
   options: {
     screens: {
-      'xs': 320,
       'sm': 640,
       'md': 768,
       'lg': 1024,
       'xl': 1280,
-      'xxl': 1536,
       '2xl': 1536,
     },
     nuxt: useNuxtApp(),


### PR DESCRIPTION
### 📚 Description

This aligns the default list of screen sizes with https://tailwindcss.com/docs/responsive-design.
