### PR TITLE
docs: fix grammar and improve clarity in providers page

### DIFF
--- a/docs/content/1.get-started/3.providers.md
+++ b/docs/content/1.get-started/3.providers.md
@@ -1,17 +1,17 @@
 ---
 title: Providers
-description: Nuxt Image supports multiple providers for high performances.
+description: Nuxt Image supports multiple providers for high performance.
 ---
 
 ## Introduction to Providers
 
 Providers are integrations between Nuxt Image and third-party image transformation services. Each provider is responsible for generating correct URLs for that image transformation service.
 
-Nuxt Image can be configured to work with any external image transformation service. Checkout sidebar for list of preconfigured providers.
+Nuxt Image can be configured to work with any external image transformation service. Checkout the sidebar for a list of preconfigured providers.
 
 If you are looking for a specific provider that is not already supported, you can [create your own provider](/advanced/custom-provider).
 
-Nuxt Image will automatically optimize `<NuxtImg>` or `<NuxtPicture>` sources and accepts all [options](/get-started/configuration) for specified target, except for modifiers that are specific to other providers.
+Nuxt Image will automatically optimize `<NuxtImg>` and `<NuxtPicture>` sources and accepts all [options](/get-started/configuration) for specified targets, except for modifiers that are specific to other providers.
 
 ## Default Provider
 
@@ -21,17 +21,17 @@ The default optimizer and provider for Nuxt Image is [ipx](/providers/ipx). Eith
 
 Images should be stored in the `public/` directory of your project.
 
-For example, when using `<NuxtImg src="/nuxt-icon.png" />`, it should be placed in `public/` folder under the path `public/nuxt-icon.png`.
+For example, when rendering a `<NuxtImg src="/nuxt-icon.png" />`, your PNG file should be placed in the `public/` directory under the path `public/nuxt-icon.png`.
 
 For more information, you can learn more about the [public directory](https://nuxt.com/docs/guide/directory-structure/public).
 
 ::note
-Image stored in the `assets/` directory are **not** processed with Nuxt Image because those images are managed by your bundler (such as Vite or webpack).
+Images stored in the `assets/` directory are **not** processed with Nuxt Image because those images are managed by your bundler (such as Vite or webpack).
 ::
 
 ### Remote Images
 
-Using default provider, you can also optimize external URLs. For this, you need to add them to [`domains`](/get-started/configuration#domains) option.
+Using the default provider, you can also optimize external URLs. For this, you need to add them to the [`domains`](/get-started/configuration#domains) option.
 
 You can also add domains for remote images by setting the `NUXT_IMAGE_DOMAINS` environment variable to a comma-separated list of domains.
 
@@ -41,7 +41,7 @@ NUXT_IMAGE_DOMAINS="example.com,yourdomain.com"
 
 ### Environment Detection
 
-You can set default provider using `NUXT_IMAGE_PROVIDER` environment variable.
+You can set the default provider using the `NUXT_IMAGE_PROVIDER` environment variable.
 
 Providers detected automatically:
 
@@ -49,4 +49,4 @@ Providers detected automatically:
 
 ### Custom Provider
 
-It is possible to define your own provider, learn more [how to create a custom provider](/advanced/custom-provider).
+It is possible to define your own provider, learn more about [how to create a custom provider](/advanced/custom-provider).


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adjusted the grammar on [this page](https://image.nuxt.com/get-started/providers) and made wording a bit clearer/consistent. For example, only using the term "directory" instead of swapping between that and "folder".


