### PR TITLE
docs: add `none` provider documentation

### DIFF
--- a/docs/content/3.providers/none.md
+++ b/docs/content/3.providers/none.md
@@ -1,0 +1,34 @@
+---
+title: None
+description: A pass-through provider that returns images without any transformations.
+links:
+  - label: Source
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/image/blob/main/src/runtime/providers/none.ts
+    size: xs
+---
+
+The `none` provider is a minimal pass-through provider that returns image URLs without applying any transformations or optimizations.
+
+This provider is useful when you want to use Nuxt Image components for consistent markup and loading behavior, but don't need actual image optimization.
+
+## Usage
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  image: {
+    provider: 'none'
+  }
+})
+```
+
+## Behavior
+
+When using the `none` provider:
+- No image transformations are applied (resizing, format conversion, etc.)
+- Modifiers are ignored
+- The original image URL is returned as-is
+- All Nuxt Image component features like lazy loading and placeholders still work
+
+This is particularly useful for development, testing, or when your images are already optimized and you just want the component interface.
+


### PR DESCRIPTION
### 🔗 Linked issue

N/A - Adding missing documentation for existing `none` provider

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds documentation for the `none` provider which has been in the codebase but was missing from the provider documentation.

The `none` provider is a pass-through provider that returns image URLs without transformations - useful for development, testing, or when images are already optimized but you still want to use Nuxt Image components for consistent markup and features like lazy loading.

The documentation is placed last in the provider list (using `none.md` prefix) since it's a special-case provider rather than a typical third-party service.