### PR TITLE
fix: fix types for custom providers shadowing builtins

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -3,7 +3,7 @@ import process from 'node:process'
 import { hasProtocol, parseURL, withLeadingSlash } from 'ufo'
 import { defineNuxtModule, addTemplate, addImports, addServerImports, createResolver, addComponent, addPlugin, addServerTemplate, addTypeTemplate } from '@nuxt/kit'
 import { join, relative, resolve } from 'pathe'
-import { resolveProviders, detectProvider, resolveProvider, BuiltInProviders } from './provider'
+import { resolveProviders, detectProvider, resolveProvider, BuiltInProviders, isBuiltInProvider } from './provider'
 import type { ImageOptions, InputProvider, CreateImageOptions, ImageModuleProvider, ImageProviders } from './types'
 import { existsSync } from 'node:fs'
 
@@ -122,7 +122,7 @@ export default defineNuxtModule<ModuleOptions>({
             provider: ${JSON.stringify(options.provider)}
           }
           interface ConfiguredImageProviders {
-${providers.map(p => `            ${JSON.stringify(p.name)}: ${p.isBuiltInProvider ? `ImageProviders[${JSON.stringify(p.name)}]` : `ReturnType<typeof import('${relative(file, p.runtime)}').default> extends ImageProvider<infer Options> ? Options : unknown `}`).join('\n')}
+${providers.map(p => `            ${JSON.stringify(p.name)}: ${isBuiltInProvider(p) ? `ImageProviders[${JSON.stringify(p.name)}]` : `ReturnType<typeof import('${relative(file, p.runtime)}').default> extends ImageProvider<infer Options> ? Options : unknown `}`).join('\n')}
           }
           interface ImageProviders {
 ${BuiltInProviders.map(p => `            ${JSON.stringify(p)}: ReturnType<typeof import('${relative(file, resolver.resolve('./runtime/providers/' + p))}').default> extends ImageProvider<infer Options> ? Options : unknown `).join('\n')}

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -54,6 +54,13 @@ export const BuiltInProviders = [
   'sirv',
 ] as const
 
+const resolver = createResolver(import.meta.url)
+const providerRuntime = resolver.resolve('./runtime/providers/')
+
+export function isBuiltInProvider(provider: ImageModuleProvider) {
+  return provider.provider?.startsWith(providerRuntime) ?? BuiltInProviders.includes(provider.name as 'ipx')
+}
+
 type ImageProviderName = typeof BuiltInProviders[number]
 
 const providerSetup: Partial<Record<ImageProviderName, ProviderSetup>> = {
@@ -127,7 +134,7 @@ export async function resolveProviders(nuxt: any, options: ModuleOptions): Promi
 
 export async function resolveProvider(_nuxt: any, key: string, input: InputProvider): Promise<ImageModuleProvider> {
   if (typeof input === 'string') {
-    input = { name: input }
+    input = { name: key, provider: input }
   }
 
   if (!input.name) {
@@ -142,9 +149,7 @@ export async function resolveProvider(_nuxt: any, key: string, input: InputProvi
     input.provider = normalizableProviders[input.provider]!()
   }
 
-  const resolver = createResolver(import.meta.url)
-  const isBuiltInProvider = BuiltInProviders.includes(input.provider as ImageProviderName)
-  input.provider = isBuiltInProvider
+  input.provider = BuiltInProviders.includes(input.provider as ImageProviderName)
     ? resolver.resolve('./runtime/providers/' + input.provider)
     : await resolvePath(input.provider)
 
@@ -152,7 +157,6 @@ export async function resolveProvider(_nuxt: any, key: string, input: InputProvi
 
   return <ImageModuleProvider> {
     ...input,
-    isBuiltInProvider,
     setup,
     runtime: normalize(input.provider!),
     importName: `${key}Runtime$${genSafeVariableName(hash(input.provider))}`,

--- a/src/types/module.ts
+++ b/src/types/module.ts
@@ -25,7 +25,6 @@ export interface ImageModuleProvider {
   importName: string
   options: any
   provider: string
-  isBuiltInProvider: boolean
   runtime: string
   runtimeOptions: any
   setup: ProviderSetup


### PR DESCRIPTION
fix correct type generation for custom providers with same name as built in providers

### 🔗 Linked issue

resolves #2015 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This fixes the ttype generation for cases where custom providers have the same name as built in providers.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
