### PR TITLE
fix(nuxt-picture): allow `data-*` in imgAttrs

### DIFF
--- a/src/runtime/components/NuxtPicture.vue
+++ b/src/runtime/components/NuxtPicture.vue
@@ -32,13 +32,14 @@ import { markFeatureUsage } from '../utils/performance'
 import { useImage } from '../composables'
 import { useImageProps } from '../utils/props'
 import type { BaseImageProps } from '../utils/props'
+import type { DataAttributes } from '../../types/image'
 import type { ConfiguredImageProviders, ProviderDefaults } from '@nuxt/image'
 
 import { useHead, useNuxtApp, useRequestEvent } from '#imports'
 
 export interface PictureProps<Provider extends keyof ConfiguredImageProviders> extends BaseImageProps<Provider> {
   legacyFormat?: string
-  imgAttrs?: ImgHTMLAttributes
+  imgAttrs?: ImgHTMLAttributes & DataAttributes
 }
 
 defineOptions({ inheritAttrs: false })

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -119,3 +119,5 @@ export interface ImageSizesVariant {
   _cWidth: number
   _cHeight?: number | undefined
 }
+
+export type DataAttributes = Record<`data-${string}`, string>


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2013 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

This fixes a typescript issue, that would give a typescript error when passing a `data-*` to NuxtImage imgAttrs prop.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
