### PR TITLE
chore: remove deprecated github silent config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,0 @@
-{
-  "github": {
-    "silent": true
-  }
-}


### PR DESCRIPTION
github silent is now deprecated. I think we may remove it. 
https://vercel.com/docs/project-configuration/git-configuration#github.silent