### PR TITLE
fix: http and https should have double slash

### DIFF
--- a/src/runtime/providers/ipxStatic.ts
+++ b/src/runtime/providers/ipxStatic.ts
@@ -20,7 +20,7 @@ export default defineProvider<Partial<IPXOptions>>({
     }
 
     return {
-      url: joinURL(baseURL, params, encodePath(src).replace(/\/{2,}/g, '/')),
+      url: joinURL(baseURL, params, encodePath(src)),
     }
   },
 })


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1084

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Currently, all URL are improperly generated.
ipxStatic will generate url like so:
`/_ipx/q_70&s_322x375/https:/images.prismic.io/interface-qc/Z9jSKjiBA97GikvL_profile_picture-1-.png%3Fauto=format,compress%26rect=27,0,322,375%26w=322%26h=375`
instead of:
`/_ipx/q_70&s_322x375/https://images.prismic.io/interface-qc/Z9jSKjiBA97GikvL_profile_picture-1-.png%3Fauto=format,compress%26rect=27,0,322,375%26w=322%26h=375`

Since removing the `.replace(/\/{2,}/g, '/')` doesn't break any test, either its not needed, either it's not the correct way to solve the problem. If it's needed, a test should probably added to test the problem it's trying to solve. 

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
