### PR TITLE
fix(bunny): merge query params with existing image src

### DIFF
--- a/src/runtime/providers/bunny.ts
+++ b/src/runtime/providers/bunny.ts
@@ -1,4 +1,4 @@
-import { joinURL } from 'ufo'
+import { withBase, withQuery, getQuery } from 'ufo'
 import { createOperationsGenerator } from '../utils/index'
 import { defineProvider } from '../utils/provider'
 
@@ -32,7 +32,7 @@ export default defineProvider<BunnyOptions>({
   getImage: (src, { modifiers, baseURL }) => {
     const operations = operationsGenerator(modifiers)
     return {
-      url: joinURL(baseURL, src + (operations ? '?' + operations : '')),
+      url: withQuery(withBase(src, baseURL), getQuery('?' + operations)),
     }
   },
 })

--- a/test/e2e/__snapshots__/bunny.json5
+++ b/test/e2e/__snapshots__/bunny.json5
@@ -1,12 +1,12 @@
 {
   "requests": [
-    "https://bunnyoptimizerdemo.b-cdn.net/bunny1.jpg?sharpen=true&aspect_ratio=16%3A9&width=1000&quality=80",
-    "https://bunnyoptimizerdemo.b-cdn.net/bunny2.jpg?crop=750%2C750&crop_gravity=north",
+    "https://bunnyoptimizerdemo.b-cdn.net/bunny1.jpg?sharpen=true&aspect_ratio=16:9&width=1000&quality=80",
+    "https://bunnyoptimizerdemo.b-cdn.net/bunny2.jpg?crop=750,750&crop_gravity=north",
     "https://bunnyoptimizerdemo.b-cdn.net/bunny3.jpg?flop=true&auto_optimize=high",
   ],
   "sources": [
-    "https://bunnyoptimizerdemo.b-cdn.net/bunny1.jpg?sharpen=true&aspect_ratio=16%3A9&width=1000&quality=80",
-    "https://bunnyoptimizerdemo.b-cdn.net/bunny2.jpg?crop=750%2C750&crop_gravity=north",
+    "https://bunnyoptimizerdemo.b-cdn.net/bunny1.jpg?sharpen=true&aspect_ratio=16:9&width=1000&quality=80",
+    "https://bunnyoptimizerdemo.b-cdn.net/bunny2.jpg?crop=750,750&crop_gravity=north",
     "https://bunnyoptimizerdemo.b-cdn.net/bunny3.jpg?flop=true&auto_optimize=high",
   ],
 }


### PR DESCRIPTION
In case the image src already contains a query parameter, it is necessary to properly add bunny query params. This is accomplished using withQuery helper from ufo.

### 🔗 Linked issue

resolves #2055

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In case the image src already contains a query parameter, it is necessary to properly add bunny query params. This is accomplished using withQuery helper from ufo.

e.g. url is http://example.com/image.jpg?timestamp

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
