### PR TITLE
feat: extend prop types from ImgHTMLAttributes

### DIFF
--- a/src/runtime/components/NuxtImg.vue
+++ b/src/runtime/components/NuxtImg.vue
@@ -29,7 +29,9 @@ import type { ProviderDefaults, ConfiguredImageProviders } from '@nuxt/image'
 
 import { useHead, useNuxtApp, useRequestEvent } from '#imports'
 
-export interface ImageProps<Provider extends keyof ConfiguredImageProviders> extends BaseImageProps<Provider> {
+export interface ImageProps<Provider extends keyof ConfiguredImageProviders>
+  extends Omit<ImgHTMLAttributes, 'sizes' | 'crossorigin' | 'placeholder'>, // we overwrite some props in our implementation
+  BaseImageProps<Provider> {
   custom?: boolean
   placeholder?: boolean | string | number | [w: number, h: number, q?: number, b?: number]
   placeholderClass?: string


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2083 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Makes the `NuxtImg` component props extend the `ImgHTMLAttributes` type so that the module can be used with a strict-prop typescript configuration. See [the issue](https://github.com/nuxt/image/issues/2083) for more details