### PR TITLE
fix: wrap importName with genSafeVariableName

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -159,7 +159,7 @@ export async function resolveProvider(_nuxt: any, key: string, input: InputProvi
     ...input,
     setup,
     runtime: normalize(input.provider!),
-    importName: `${key}Runtime$${genSafeVariableName(hash(input.provider))}`,
+    importName: genSafeVariableName(`${key}Runtime$${hash(input.provider)}`),
     runtimeOptions: input.options,
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

fix https://github.com/nuxt/image/issues/2093
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR wraps `importName` with `genSafeVariable` so users can use kebab-cased key. 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
