### PR TITLE
feat: allow to modify provider options within props

### DIFF
--- a/src/runtime/utils/props.ts
+++ b/src/runtime/utils/props.ts
@@ -39,9 +39,9 @@ export const useImageProps = <Provider extends keyof ConfiguredImageProviders>(p
   const $img = useImage()
 
   const providerOptions = computed(() => ({
+    ...props.options,
     provider: props.provider,
     preset: props.preset,
-    ...props.options,
   }))
 
   const normalizedAttrs = computed(() => ({

--- a/src/runtime/utils/props.ts
+++ b/src/runtime/utils/props.ts
@@ -20,6 +20,8 @@ export interface BaseImageProps<Provider extends keyof ConfiguredImageProviders>
   preset?: string
   provider?: Provider
 
+  options?: ConfiguredImageProviders[Provider]
+
   sizes?: string | Record<string, any>
   densities?: string
   preload?: boolean | { fetchPriority: 'auto' | 'high' | 'low' }
@@ -39,6 +41,7 @@ export const useImageProps = <Provider extends keyof ConfiguredImageProviders>(p
   const providerOptions = computed(() => ({
     provider: props.provider,
     preset: props.preset,
+    ...props.options,
   }))
 
   const normalizedAttrs = computed(() => ({

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -9,7 +9,7 @@ export interface ImageModifiers {
   format: string
   quality: string | number
   background: string
-  blur: number
+  blur: number | string
 }
 
 export interface ResolvedImageModifiers extends ImageModifiers {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

related to https://github.com/nuxt/image/pull/2100

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When working on https://github.com/nuxt/image/pull/2100 . I noticed that `accountHash` shouldn't be in modifiers, and should be something easily modifiable at runtime (users can have multiple providers)

 this PR allows to send new options thorugh `nuxtImg` and `nuxtPicture` props with `options` attribute. It also allows to have `{ baseUrl }` configurable when a component renders.

Small example of what could be possible

```ts
    <nuxt-img
     v-for="img in storedImages"
      :provider="img.provider"
      :src="img.src"
      :options="{
        baseURL: img.baseURL
      }"
      width="500"
      height="500"
    />
```

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
