### PR TITLE
docs: add sharp cross-platform installation section

### DIFF
--- a/docs/content/1.get-started/1.installation.md
+++ b/docs/content/1.get-started/1.installation.md
@@ -43,7 +43,9 @@ Then, add it to the `modules` in your `nuxt.config`:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({
-  modules: ['@nuxt/image']
+  modules: [
+    '@nuxt/image'
+  ]
 })
 ```
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This might help a few Nuxt Image users in troubleshooting an error related to missing sharp binaries.