### PR TITLE
fix!: require `src` prop in `<NuxtImg>` and `<NuxtPicture>`

### DIFF
--- a/src/runtime/components/NuxtImg.vue
+++ b/src/runtime/components/NuxtImg.vue
@@ -47,7 +47,7 @@ defineSlots<{ default(props: DefaultSlotProps): any }>()
 const $img = useImage()
 const { providerOptions, normalizedAttrs, imageModifiers } = useImageProps(props)
 
-const sizes = computed(() => $img.getSizes(props.src!, {
+const sizes = computed(() => $img.getSizes(props.src, {
   ...providerOptions.value,
   sizes: props.sizes,
   densities: props.densities,
@@ -86,7 +86,7 @@ const placeholder = computed(() => {
     ? placeholder
     : typeof placeholder === 'number' ? [placeholder] : []
 
-  return $img(props.src!, {
+  return $img(props.src, {
     ...imageModifiers.value,
     width,
     height,
@@ -98,7 +98,7 @@ const placeholder = computed(() => {
 const mainSrc = computed(() =>
   props.sizes
     ? sizes.value.src
-    : $img(props.src!, imageModifiers.value, providerOptions.value),
+    : $img(props.src, imageModifiers.value, providerOptions.value),
 )
 
 const src = computed(() => placeholder.value || mainSrc.value)

--- a/src/runtime/components/NuxtPicture.vue
+++ b/src/runtime/components/NuxtPicture.vue
@@ -78,7 +78,7 @@ const attrs = computed(() => {
   return attrs
 })
 
-const originalFormat = computed(() => props.src?.match(/^[^?#]+\.(\w+)(?:$|[?#])/)?.[1])
+const originalFormat = computed(() => props.src.match(/^[^?#]+\.(\w+)(?:$|[?#])/)?.[1])
 
 const legacyFormat = computed(() => {
   if (props.legacyFormat) {
@@ -97,7 +97,7 @@ const sources = computed<Source[]>(() => {
   const formats = props.format?.split(',') || (originalFormat.value === 'svg' ? ['svg'] : ($img.options.format?.length ? [...$img.options.format] : ['webp']))
 
   if (formats[0] === 'svg') {
-    return [{ src: props.src! }]
+    return [{ src: props.src }]
   }
 
   if (!formats.includes(legacyFormat.value)) {
@@ -109,7 +109,7 @@ const sources = computed<Source[]>(() => {
   }
 
   return formats.map((format) => {
-    const { srcset, sizes, src } = $img.getSizes(props.src!, {
+    const { srcset, sizes, src } = $img.getSizes(props.src, {
       ...providerOptions.value,
       sizes: props.sizes || $img.options.screens,
       densities: props.densities,

--- a/src/runtime/utils/props.ts
+++ b/src/runtime/utils/props.ts
@@ -6,7 +6,7 @@ import { useImage } from '#imports'
 
 export interface BaseImageProps<Provider extends keyof ConfiguredImageProviders> {
   // input source
-  src?: string
+  src: string
 
   // modifiers
   format?: string


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

Marks `src` prop as required in `BaseImageProps` type (shared by both NuxtImg and NuxtPicture components).