### PR TITLE
feat(nuxt-img): allow setting `placeholder` and `placeholderClass` via presets

### DIFF
--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -23,6 +23,12 @@ export interface ImageOptions<Provider extends keyof ConfiguredImageProviders = 
   provider?: Provider
   preset?: string
   densities?: string
+  placeholder?:
+    | boolean
+    | string
+    | number
+    | [w: number, h: number, q?: number, b?: number]
+  placeholderClass?: string
   modifiers?: Partial<Omit<ImageModifiers, 'format' | 'quality' | 'background' | 'fit'>>
     & ('modifiers' extends keyof ConfiguredImageProviders[Provider] ? ConfiguredImageProviders[Provider]['modifiers'] : Record<string, unknown>)
   sizes?: string | Record<string, any>

--- a/test/nuxt/image.test.ts
+++ b/test/nuxt/image.test.ts
@@ -392,7 +392,7 @@ describe('Sizes and densities behavior', () => {
   })
 })
 
-describe('Preset sizes and densities inheritance', () => {
+describe('Preset inheritance', () => {
   const src = '/image.png'
 
   beforeEach(() => {
@@ -504,6 +504,34 @@ describe('Preset sizes and densities inheritance', () => {
     expect(srcset).toMatch(/\s2x\b/)
     expect(srcset).not.toMatch(/\b\d+w\b/)
     expect(sizes).toBeFalsy()
+  })
+
+  it('preset placeholder and placeholderClass are inherited', () => {
+    setImageContext({
+      presets: {
+        withPlaceholder: {
+          placeholder: true,
+          placeholderClass: 'placeholder-class',
+        },
+      },
+    })
+
+    const wrapper = mount(NuxtImg, {
+      propsData: {
+        src,
+        width: 200,
+        height: 200,
+        preset: 'withPlaceholder',
+      },
+    })
+
+    const imgElement = wrapper.find('img').element
+    const domSrc = imgElement.getAttribute('src')
+
+    expect(domSrc).toMatchInlineSnapshot(
+      '"/_ipx/q_50&blur_3&s_10x10/image.png"',
+    )
+    expect(imgElement.classList).toContain('placeholder-class')
   })
 })
 

--- a/test/unit/bundle.test.ts
+++ b/test/unit/bundle.test.ts
@@ -21,7 +21,7 @@ describe.skipIf(process.env.ECOSYSTEM_CI || isWindows)('nuxt image bundle size',
       image: { provider: 'ipx' },
     })
 
-    expect(roundToKilobytes(withImage.totalBytes - withoutImage.totalBytes)).toMatchInlineSnapshot(`"12.6k"`)
+    expect(roundToKilobytes(withImage.totalBytes - withoutImage.totalBytes)).toMatchInlineSnapshot(`"12.8k"`)
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/image/issues/1256

### 📚 Description

This allows setting `placeholder` and `placeholderClass` props via presets.