### PR TITLE
fix(cloudflare): add `baseURL` for urls with no operations

### DIFF
--- a/src/runtime/providers/cloudflare.ts
+++ b/src/runtime/providers/cloudflare.ts
@@ -1,4 +1,4 @@
-import { encodeQueryItem, joinURL } from 'ufo'
+import { encodeQueryItem, hasProtocol, joinURL } from 'ufo'
 import { createOperationsGenerator } from '../utils/index'
 import { defineProvider } from '../utils/provider'
 
@@ -46,7 +46,7 @@ export default defineProvider<CloudflareOptions>({
     const operations = operationsGenerator(mergeModifiers as any)
 
     // https://<ZONE>/cdn-cgi/image/<OPTIONS>/<SOURCE-IMAGE>
-    const url = operations ? joinURL(baseURL, 'cdn-cgi/image', operations, src) : src
+    const url = operations ? joinURL(baseURL, 'cdn-cgi/image', operations, src) : hasProtocol(src) ? src : joinURL(baseURL, src)
 
     return {
       url,


### PR DESCRIPTION
Co-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>

### 🔗 Linked issue

### 📚 Description

I've added hasProtocol(src) to decide wether the src url can be returned as is or if it needs the baseURL prepended.

The bug was introduced with this change:
https://github.com/nuxt/image/pull/1790/changes/c68e1112393683fa057c96fd8dc551a4c32b7732#diff-1982745bb2a7ce7f4f529e1d43edfb0b98a52d03876e61b5dbaf9fb2ac28dda3

and the currently open PR:
https://github.com/nuxt/image/pull/2126

did not fix the issue for me, because it uses the nuxt.baseURL and not the one configured for the provider.
