### PR TITLE
Encode querystring separators before URL turned into static path

### DIFF
--- a/src/runtime/providers/ipxStatic.ts
+++ b/src/runtime/providers/ipxStatic.ts
@@ -14,13 +14,14 @@ export default defineProvider<Partial<IPXOptions>>({
     }
 
     const params = operationsGenerator(modifiers) || '_'
+    const encodedSrc = src.replace(/\?/g, '%3F').replace(/&/g, '%26').replace(/=/g, '%3D')
 
     if (!baseURL) {
       baseURL = joinURL(ctx.options.nuxt.baseURL, '/_ipx')
     }
 
     return {
-      url: joinURL(baseURL, params, encodePath(src).replace(/\/{2,}/g, '/')),
+      url: joinURL(baseURL, params, encodePath(encodedSrc).replace(/\/{2,}/g, '/')),
     }
   },
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/image/issues/2029#issuecomment-3554746972
Possibly https://github.com/nuxt/image/issues/815 and https://github.com/nuxt/image/issues/2039

### 📚 Description

When using ipxStatic (nuxt generate), if the remote image URL's own query string operators - ?, & and = are left raw, they can be interpreted as part of the IPX request URL/query instead of as part of the remote image URL. Encoding them keeps the full remote URL intact as the image source. 

Reproduction - `nuxt generate` and `npx serve .output/public`

Before fix (image doesn't load)  - https://github.com/TechAkayy/nuxt-image-generate-issue/tree/main
After fix (image loads fine) - https://github.com/TechAkayy/nuxt-image-generate-issue/tree/pr-2224

Remote image URL like this:

`https://images.unsplash.com/photo-1654870468927-92c943da24fe?crop=entropy&cs=srgb&fm=jpg&ixid=M3wyMDkyMnwwfDF8c2VhcmNofDQ5fHxiYWtlcnklMjBjYWtlfGVufDB8fHx8MTY5NTA5NzYyNXww&ixlib=rb-4.0.3&q=85`

gets transformed into:

`https://images.unsplash.com/photo-1654870468927-92c943da24fe%3Fcrop%3Dentropy%26cs%3Dsrgb%26fm%3Djpg%26ixid%3DM3wyMDkyMnwwfDF8c2VhcmNofDQ5fHxiYWtlcnklMjBjYWtlfGVufDB8fHx8MTY5NTA5NzYyNXww%26ixlib%3Drb-4.0.3%26q%3D85`

before the URL is further transformed into ipx source path like this `/_ipx/w_10&q_70/https:/images.unsplash.com/...`