### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "optionalDependencies": {
     "ipx": "^3.1.1"
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.1.2",
   "engines": {
     "node": ">=18.20.6"
   }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,18 +5,15 @@ packages:
 
 verifyDepsBeforeRun: install
 
-onlyBuiltDependencies:
-  - better-sqlite3
-  - sharp
-
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-  - vue-demi
-
-
 overrides:
   "@nuxt/image": "workspace:*"
   "@nuxt/schema": "4.4.5"
   "@types/node": "^24.12.4"
   vue: "3.5.34"
+
+allowBuilds:
+  "@parcel/watcher": false
+  better-sqlite3: true
+  esbuild: false
+  sharp: true
+  vue-demi: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,4 +16,5 @@ allowBuilds:
   better-sqlite3: true
   esbuild: false
   sharp: true
+  unrs-resolver: false
   vue-demi: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`
