### PR TITLE
feat(sanity): add configurable `baseURL` option to Sanity provider

### DIFF
--- a/src/runtime/providers/sanity.ts
+++ b/src/runtime/providers/sanity.ts
@@ -64,6 +64,7 @@ const getMetadata = (id: string) => {
 interface SanityOptions {
   projectId: string
   dataset?: string
+  baseURL?: string
   modifiers?: {
     'crop'?: string | { left: number, top: number, right: number, bottom: number }
     'rect'?: `${number},${number},${number},${number}`
@@ -76,7 +77,7 @@ interface SanityOptions {
 }
 
 export default defineProvider<SanityOptions>({
-  getImage: (src, { modifiers, projectId, dataset = 'production' }) => {
+  getImage: (src, { modifiers, projectId, dataset = 'production', baseURL = sanityCDN }) => {
     const { height: sourceHeight, width: sourceWidth } = getMetadata(src)
     if (modifiers.crop && typeof modifiers.crop !== 'string' && sourceWidth && sourceHeight) {
       const left = modifiers.crop.left * sourceWidth
@@ -108,7 +109,7 @@ export default defineProvider<SanityOptions>({
     const filenameAndQueries = parts.join('-') + '.' + format + (operations ? ('?' + operations) : '')
 
     return {
-      url: joinURL(sanityCDN, projectId, dataset, filenameAndQueries),
+      url: joinURL(baseURL, projectId, dataset, filenameAndQueries),
     }
   },
 })

--- a/test/nuxt/providers.test.ts
+++ b/test/nuxt/providers.test.ts
@@ -476,7 +476,6 @@ describe('Providers', () => {
 
   it('sanity', () => {
     const providerOptions = {
-      baseURL: '',
       projectId: 'projectid',
     }
 
@@ -485,6 +484,10 @@ describe('Providers', () => {
       const generated = sanity().getImage('image-test-300x450-png', { modifiers: { ...modifiers }, ...providerOptions }, getEmptyContext())
       expect(generated).toMatchObject(image.sanity)
     }
+
+    // baseURL: '/api/sanity/images'
+    expect(sanity().getImage('image-test-300x450-png', { baseURL: '/api/sanity/images', modifiers: {}, ...providerOptions }, getEmptyContext()))
+      .toMatchObject({ url: '/api/sanity/images/projectid/production/test-300x450.png?auto=format' })
   })
 
   it('shopify', () => {


### PR DESCRIPTION
### 🔗 Linked issue

Closes #2272 

### 📚 Description

#### Summary
Add an optional `baseURL` configuration to the Sanity image provider, allowing users to override the default CDN URL (https://cdn.sanity.io/images).

#### Motivation
The Sanity CDN URL is currently hardcoded. This makes it impossible to use the provider with:

- Custom CDN or proxy setups: https://www.sanity.io/answers/how-to-create-custom-url-for-the-cdn-without-enterprise
- Custom domain for Enterprise plans: https://www.sanity.io/answers/how-to-use-a-custom-domain-name-for-the-cdn

#### Changes
- Added an optional `baseURL` property to `SanityOptions` (defaults to https://cdn.sanity.io/images when not specified).
- Used `baseURL` in the final `joinURL()` call instead of the hardcoded constant.
- Added a test for the `baseURL` option in `providers.test.ts`.

This is a backward-compatible change. Existing configurations without `baseURL` will behave exactly as before.

#### Example usage
```ts
export default defineNuxtConfig({
  image: {
    sanity: {
      projectId: 'yourprojectid',
      // Optional: override the default Sanity CDN URL
      baseURL: 'https://your-custom-cdn.example.com/images',
    }
  }
})
```