### PR TITLE
feat(sanity): support absolute URLs with project and dataset extraction

### DIFF
--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@nuxt/test-utils="4.0.0"
+setups.@nuxt/test-utils="4.0.3"

--- a/src/runtime/providers/sanity.ts
+++ b/src/runtime/providers/sanity.ts
@@ -1,4 +1,4 @@
-import { joinURL, encodePath, hasProtocol } from 'ufo'
+import { joinURL, encodePath, hasProtocol, withQuery, parseQuery } from 'ufo'
 import { createOperationsGenerator } from '../utils/index'
 import { defineProvider } from '../utils/provider'
 
@@ -78,8 +78,11 @@ interface SanityOptions {
 
 export default defineProvider<SanityOptions>({
   getImage: (src, { modifiers, projectId, dataset, baseURL = sanityCDN }) => {
-    const [_projectId, _dataset, _src] = hasProtocol(src) ? src.split('/').slice(-3) : [projectId, dataset, src]
-    const { height: sourceHeight, width: sourceWidth } = getMetadata(_src)
+    const isAbsolute = hasProtocol(src)
+    const [_projectId, _dataset, _segment] = isAbsolute ? src.split('/').slice(-3) : [projectId, dataset, src]
+    const [_id] = isAbsolute ? _segment.split('?') : [src]
+    const { height: sourceHeight, width: sourceWidth } = getMetadata(_id)
+
     if (modifiers.crop && typeof modifiers.crop !== 'string' && sourceWidth && sourceHeight) {
       const left = modifiers.crop.left * sourceWidth
       const top = modifiers.crop.top * sourceHeight
@@ -102,13 +105,14 @@ export default defineProvider<SanityOptions>({
     if (modifiers.fit === 'contain' && !modifiers.bg) {
       modifiers.bg = 'ffffff'
     }
-    const operations = operationsGenerator(modifiers)
 
+    const operations = operationsGenerator(modifiers)
     const parts = src.split('-').slice(1)
     const format = parts.pop()
-    const query = (operations ? ('?' + operations) : '')
-
-    const filenameAndQueries = (hasProtocol(src) ? _src : `${parts.join('-')}.${format}`) + query
+    const filenameAndQueries = withQuery(
+      isAbsolute ? _segment : `${parts.join('-')}.${format}`,
+      parseQuery(operations),
+    )
 
     return {
       url: joinURL(baseURL, projectId || _projectId, dataset || _dataset || 'production', filenameAndQueries),

--- a/src/runtime/providers/sanity.ts
+++ b/src/runtime/providers/sanity.ts
@@ -80,7 +80,7 @@ export default defineProvider<SanityOptions>({
   getImage: (src, { modifiers, projectId, dataset, baseURL = sanityCDN }) => {
     const isAbsolute = hasProtocol(src)
     const [_projectId, _dataset, _segment] = isAbsolute ? src.split('/').slice(-3) : [projectId, dataset, src]
-    const [_id] = isAbsolute ? _segment.split('?') : [src]
+    const _id = (isAbsolute ? _segment?.split('?')[0] : src) ?? ''
     const { height: sourceHeight, width: sourceWidth } = getMetadata(_id)
 
     if (modifiers.crop && typeof modifiers.crop !== 'string' && sourceWidth && sourceHeight) {

--- a/src/runtime/providers/sanity.ts
+++ b/src/runtime/providers/sanity.ts
@@ -1,4 +1,4 @@
-import { joinURL, encodePath } from 'ufo'
+import { joinURL, encodePath, hasProtocol } from 'ufo'
 import { createOperationsGenerator } from '../utils/index'
 import { defineProvider } from '../utils/provider'
 
@@ -77,8 +77,9 @@ interface SanityOptions {
 }
 
 export default defineProvider<SanityOptions>({
-  getImage: (src, { modifiers, projectId, dataset = 'production', baseURL = sanityCDN }) => {
-    const { height: sourceHeight, width: sourceWidth } = getMetadata(src)
+  getImage: (src, { modifiers, projectId, dataset, baseURL = sanityCDN }) => {
+    const [_projectId, _dataset, _src] = hasProtocol(src) ? src.split('/').slice(-3) : [projectId, dataset, src]
+    const { height: sourceHeight, width: sourceWidth } = getMetadata(_src)
     if (modifiers.crop && typeof modifiers.crop !== 'string' && sourceWidth && sourceHeight) {
       const left = modifiers.crop.left * sourceWidth
       const top = modifiers.crop.top * sourceHeight
@@ -105,11 +106,12 @@ export default defineProvider<SanityOptions>({
 
     const parts = src.split('-').slice(1)
     const format = parts.pop()
+    const query = (operations ? ('?' + operations) : '')
 
-    const filenameAndQueries = parts.join('-') + '.' + format + (operations ? ('?' + operations) : '')
+    const filenameAndQueries = (hasProtocol(src) ? _src : `${parts.join('-')}.${format}`) + query
 
     return {
-      url: joinURL(baseURL, projectId, dataset, filenameAndQueries),
+      url: joinURL(baseURL, projectId || _projectId, dataset || _dataset || 'production', filenameAndQueries),
     }
   },
 })

--- a/test/nuxt/providers.test.ts
+++ b/test/nuxt/providers.test.ts
@@ -489,7 +489,7 @@ describe('Providers', () => {
     expect(sanity().getImage('image-test-300x450-png', { baseURL: '/api/sanity/images', modifiers: {}, ...providerOptions }, getEmptyContext()))
       .toMatchObject({ url: '/api/sanity/images/projectid/production/test-300x450.png?auto=format' })
   })
-  it('sanity with absolute url and preexisting query params', () => {
+  it('sanity with absolute url and option overrides', () => {
     const originalUrl = 'https://cdn.sanity.io/images/xenf4f6n/redesign/228cc6aa1c47854699f13c35719073cfcaf7ee54-1552x982.png'
 
     // @ts-expect-error `projectId` is extracted from the absolute URL
@@ -508,6 +508,29 @@ describe('Providers', () => {
     // projectId: '', dataset: '' → inherit
     expect(sanity().getImage(originalUrl, { modifiers: { height: 10, blur: 2, quality: 10 }, projectId: '', dataset: '' }, getEmptyContext()))
       .toMatchObject({ url: 'https://cdn.sanity.io/images/xenf4f6n/redesign/228cc6aa1c47854699f13c35719073cfcaf7ee54-1552x982.png?h=10&blur=2&q=10&auto=format' })
+  })
+  it('sanity with absolute url and preexisting query params', () => {
+    const originalUrl = 'https://cdn.sanity.io/images/xenf4f6n/redesign/228cc6aa1c47854699f13c35719073cfcaf7ee54-1552x982.png'
+
+    // single existing param
+    // @ts-expect-error `projectId` is extracted from the absolute URL
+    expect(sanity().getImage(originalUrl + '?w=999', { modifiers: { height: 10 } }, getEmptyContext()))
+      .toMatchObject({ url: originalUrl + '?w=999&h=10&auto=format' })
+
+    // multiple existing params
+    // @ts-expect-error `projectId` is extracted from the absolute URL
+    expect(sanity().getImage(originalUrl + '?w=999&q=92', { modifiers: { height: 10 } }, getEmptyContext()))
+      .toMatchObject({ url: originalUrl + '?w=999&q=92&h=10&auto=format' })
+
+    // '?' with no param
+    // @ts-expect-error `projectId` is extracted from the absolute URL
+    expect(sanity().getImage(originalUrl + '?', { modifiers: { height: 10 } }, getEmptyContext()))
+      .toMatchObject({ url: originalUrl + '?h=10&auto=format' })
+
+    // param override
+    // @ts-expect-error `projectId` is extracted from the absolute URL
+    expect(sanity().getImage(originalUrl + '?w=999&q=92', { modifiers: { height: 10, width: 420 } }, getEmptyContext()))
+      .toMatchObject({ url: originalUrl + '?w=420&q=92&h=10&auto=format' })
   })
 
   it('shopify', () => {

--- a/test/nuxt/providers.test.ts
+++ b/test/nuxt/providers.test.ts
@@ -489,6 +489,26 @@ describe('Providers', () => {
     expect(sanity().getImage('image-test-300x450-png', { baseURL: '/api/sanity/images', modifiers: {}, ...providerOptions }, getEmptyContext()))
       .toMatchObject({ url: '/api/sanity/images/projectid/production/test-300x450.png?auto=format' })
   })
+  it('sanity with absolute url and preexisting query params', () => {
+    const originalUrl = 'https://cdn.sanity.io/images/xenf4f6n/redesign/228cc6aa1c47854699f13c35719073cfcaf7ee54-1552x982.png'
+
+    // @ts-expect-error `projectId` is extracted from the absolute URL
+    const generated = sanity().getImage(originalUrl, { modifiers: { height: 10, blur: 2, quality: 10 } }, getEmptyContext())
+    expect(generated).toMatchObject({ url: 'https://cdn.sanity.io/images/xenf4f6n/redesign/228cc6aa1c47854699f13c35719073cfcaf7ee54-1552x982.png?h=10&blur=2&q=10&auto=format' })
+
+    // projectId: 'projectid' → overwrite
+    expect(sanity().getImage(originalUrl, { modifiers: { height: 10, blur: 2, quality: 10 }, projectId: 'projectid' }, getEmptyContext()))
+      .toMatchObject({ url: 'https://cdn.sanity.io/images/projectid/redesign/228cc6aa1c47854699f13c35719073cfcaf7ee54-1552x982.png?h=10&blur=2&q=10&auto=format' })
+
+    // dataset: 'dataset' → overwrite
+    // @ts-expect-error `projectId` is extracted from the absolute URL
+    expect(sanity().getImage(originalUrl, { modifiers: { height: 10, blur: 2, quality: 10 }, dataset: 'dataset' }, getEmptyContext()))
+      .toMatchObject({ url: 'https://cdn.sanity.io/images/xenf4f6n/dataset/228cc6aa1c47854699f13c35719073cfcaf7ee54-1552x982.png?h=10&blur=2&q=10&auto=format' })
+
+    // projectId: '', dataset: '' → inherit
+    expect(sanity().getImage(originalUrl, { modifiers: { height: 10, blur: 2, quality: 10 }, projectId: '', dataset: '' }, getEmptyContext()))
+      .toMatchObject({ url: 'https://cdn.sanity.io/images/xenf4f6n/redesign/228cc6aa1c47854699f13c35719073cfcaf7ee54-1552x982.png?h=10&blur=2&q=10&auto=format' })
+  })
 
   it('shopify', () => {
     const providerOptions = {

--- a/test/unit/bundle.test.ts
+++ b/test/unit/bundle.test.ts
@@ -21,7 +21,7 @@ describe.skipIf(process.env.ECOSYSTEM_CI || isWindows)('nuxt image bundle size',
       image: { provider: 'ipx' },
     })
 
-    expect(roundToKilobytes(withImage.totalBytes - withoutImage.totalBytes)).toMatchInlineSnapshot(`"12.6k"`)
+    expect(roundToKilobytes(withImage.totalBytes - withoutImage.totalBytes)).toMatchInlineSnapshot(`"12.7k"`)
   })
 })
 

--- a/test/unit/bundle.test.ts
+++ b/test/unit/bundle.test.ts
@@ -21,7 +21,7 @@ describe.skipIf(process.env.ECOSYSTEM_CI || isWindows)('nuxt image bundle size',
       image: { provider: 'ipx' },
     })
 
-    expect(roundToKilobytes(withImage.totalBytes - withoutImage.totalBytes)).toMatchInlineSnapshot(`"12.7k"`)
+    expect(roundToKilobytes(withImage.totalBytes - withoutImage.totalBytes)).toMatchInlineSnapshot(`"12.6k"`)
   })
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

Closes #1297

### 📚 Description

#### Summary

Absolute URLs from Sanity's CDN can now be passed directly as the image source. The provider will now extract `projectId` and `dataset` from the URL but they can still be overridden via options if necessary (not sure why but accounted for).

#### Changes
- Extracts `projectId`, `dataset` and `filename` from the URL path when `src` is an absolute URL
- Uses a fallback chain: provided options > extracted from URL > provider defaults ensuring explicit config always wins
- Handles falsy options (e.g. `projectId: ''`) correctly, falling back to the URL value with test to prevent future regresisons
- All existing non-URL usage remains unchanged (as long as it had tests)

Backwards-compatible change. Existing configurations with projectId and asset IDs will work exactly as before.

#### Notes
- I left `@ts-expect-error` comments on the tests in order to not change the type signature of `SanityOptions`
- I commited an updated revision of `.nuxtrc` but I can revert or delete it from the repo (precedent https://github.com/nuxt/image/commit/8341b16a16ee87d52565640bed6f3e7077575991)

----

~~I'm really sorry for the extra bytes 🙏 .~~

~~Hope someone from e18n can shave at least twice as many from any of our deps 🤞~~

Seems like there was a missmatch between my machine and CI so it wasn't necessary to make any changes to the snapshot and I technically didn't make things worse 😈 