### PR TITLE
chore: move `consola` to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "@nuxt/kit": "^4.4.8",
-    "consola": "^3.4.2",
     "defu": "^6.1.7",
     "h3": "^1.15.11",
     "image-meta": "^0.2.2",
@@ -68,6 +67,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "@vue/test-utils": "^2.4.11",
     "changelogen": "^0.6.2",
+    "consola": "^3.4.2",
     "eslint": "10.5.0",
     "happy-dom": "^20.10.3",
     "installed-check": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@nuxt/kit':
         specifier: ^4.4.8
         version: 4.4.8(magicast@0.5.3)
-      consola:
-        specifier: ^3.4.2
-        version: 3.4.2
       defu:
         specifier: ^6.1.7
         version: 6.1.7
@@ -75,6 +72,9 @@ importers:
       changelogen:
         specifier: ^0.6.2
         version: 0.6.2(magicast@0.5.3)
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
       eslint:
         specifier: 10.5.0
         version: 10.5.0(jiti@2.7.0)
@@ -7944,6 +7944,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0


### PR DESCRIPTION
### 🔗 Linked issue

*no response*

### 📚 Description

`consola` has not been imported directly at runtime.