### PR TITLE
docs(shopify): update NuxtImg syntax to use v-bind for modifiers

### DIFF
--- a/docs/content/3.providers/shopify.md
+++ b/docs/content/3.providers/shopify.md
@@ -47,7 +47,7 @@ Additionally, the following modifiers are supported:
 The `format` modifier is supported.
 
 ```vue
-<NuxtImg src="..." width="300" height="300" modifiers="{ format: 'gif' }" />
+<NuxtImg src="..." width="300" height="300" :modifiers="{ format: 'gif' }" />
 ```
 
 ### Quality
@@ -55,7 +55,7 @@ The `format` modifier is supported.
 The `quality` modifier is supported.
 
 ```vue
-<NuxtImg src="..." width="300" height="300" modifiers="{ quality: 10 }" />
+<NuxtImg src="..." width="300" height="300" :modifiers="{ quality: 10 }" />
 ```
 
 ### Crop
@@ -70,7 +70,7 @@ The `crop` modifier is supported with the following values:
 - `region`
 
 ```vue
-<NuxtImg src="..." width="300" height="300" modifiers="{ crop: 'center' }" />
+<NuxtImg src="..." width="300" height="300" :modifiers="{ crop: 'center' }" />
 ```
 
 #### Crop Region
@@ -82,7 +82,7 @@ The `crop` modifier can also be used to crop an image to a specific region.
   src="..." 
   width="300" 
   height="300" 
-  modifiers="{ 
+  :modifiers="{ 
     crop: 'region', 
     cropLeft: 100, 
     cropTop: 100, 
@@ -97,5 +97,5 @@ The `crop` modifier can also be used to crop an image to a specific region.
 The `padColor` modifier can be used to pad an image with a background color. Must be a hex color value.
 
 ```vue
-<NuxtImg src="..." width="300" height="300" modifiers="{ padColor: 'ff0000' }" />
+<NuxtImg src="..." width="300" height="300" :modifiers="{ padColor: 'ff0000' }" />
 ```


### PR DESCRIPTION
This pull request updates the documentation for the Shopify image provider to correct how the `modifiers` prop is passed to the `NuxtImg` component. All examples now use the correct Vue binding syntax for props.

**Documentation fixes:**

* Updated all `NuxtImg` usage examples to use `:modifiers="{ ... }"` instead of `modifiers="{ ... }"` to properly bind the `modifiers` prop as an object in Vue. [[1]](diffhunk://#diff-c5d74cfc2eac5dfa091de06c46cef70014cb9e6ac3bbc07ad35a1eca5c9e4228L50-R58) [[2]](diffhunk://#diff-c5d74cfc2eac5dfa091de06c46cef70014cb9e6ac3bbc07ad35a1eca5c9e4228L73-R73) [[3]](diffhunk://#diff-c5d74cfc2eac5dfa091de06c46cef70014cb9e6ac3bbc07ad35a1eca5c9e4228L85-R85) [[4]](diffhunk://#diff-c5d74cfc2eac5dfa091de06c46cef70014cb9e6ac3bbc07ad35a1eca5c9e4228L100-R100)