### PR TITLE
feat(awsAmplify,vercel): make `minimumCacheTTL` configurable

### DIFF
--- a/docs/content/3.providers/aws-amplify.md
+++ b/docs/content/3.providers/aws-amplify.md
@@ -81,3 +81,20 @@ export default defineNuxtConfig({
   }
 })
 ```
+
+### `minimumCacheTTL`
+
+- Type: **Number** (optional)
+
+Configure the minimum cache lifetime in seconds for optimized images.
+By default, the provider uses `300`.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  image: {
+    awsAmplify: {
+      minimumCacheTTL: 3600
+    }
+  }
+})
+```

--- a/docs/content/3.providers/vercel.md
+++ b/docs/content/3.providers/vercel.md
@@ -87,3 +87,20 @@ export default defineNuxtConfig({
   }
 })
 ```
+
+### `minimumCacheTTL`
+
+- Type: **Number** (optional)
+
+Configure the minimum cache lifetime in seconds for optimized images.
+By default, the provider uses `300`.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  image: {
+    vercel: {
+      minimumCacheTTL: 3600
+    }
+  }
+})
+```

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -93,7 +93,7 @@ const providerSetup: Partial<Record<ImageProviderName, ProviderSetup>> = {
         config: {
           images: {
             domains: moduleOptions.domains,
-            minimumCacheTTL: 60 * 5,
+            minimumCacheTTL: providerOptions.options?.minimumCacheTTL ?? 60 * 5,
             sizes: Array.from(new Set(Object.values(moduleOptions.screens || {}))),
             formats: providerOptions.options?.formats ?? ['image/webp', 'image/avif'],
           },
@@ -112,7 +112,7 @@ const providerSetup: Partial<Record<ImageProviderName, ProviderSetup>> = {
         imageSettings: {
           sizes: Array.from(new Set(Object.values(moduleOptions.screens || {}))),
           formats: providerOptions.options?.formats ?? ['image/jpeg', 'image/png', 'image/webp', 'image/avif'],
-          minimumCacheTTL: 60 * 5,
+          minimumCacheTTL: providerOptions.options?.minimumCacheTTL ?? 60 * 5,
           domains: moduleOptions.domains,
           remotePatterns: [], // Provided by domains
           dangerouslyAllowSVG: false, // TODO

--- a/src/runtime/providers/awsAmplify.ts
+++ b/src/runtime/providers/awsAmplify.ts
@@ -52,6 +52,7 @@ const operationsGenerator = createOperationsGenerator({
 interface AmplifyOptions {
   baseURL?: string
   formats?: NonNullable<NonNullable<NitroConfig['awsAmplify']>['imageSettings']>['formats']
+  minimumCacheTTL?: NonNullable<NonNullable<NitroConfig['awsAmplify']>['imageSettings']>['minimumCacheTTL']
   modifiers?: {
     quality?: string | number
     // TODO: more modifiers

--- a/src/runtime/providers/vercel.ts
+++ b/src/runtime/providers/vercel.ts
@@ -7,6 +7,7 @@ import { defineProvider } from '../utils/provider'
 interface VercelOptions {
   baseURL?: string
   formats?: NonNullable<NonNullable<NonNullable<NitroConfig['vercel']>['config']>['images']>['formats']
+  minimumCacheTTL?: NonNullable<NonNullable<NonNullable<NitroConfig['vercel']>['config']>['images']>['minimumCacheTTL']
   modifiers?: {
     quality?: string | number
   }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/image/issues/2271

### 📚 Description

Allows configuring `minimumCacheTTL` for AWS Amplify and Vercel providers. Falls back to the default value if not provided.