### PR TITLE
fix: remove duplicated `provider` key in generated image options

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -235,16 +235,20 @@ function pick<O extends Record<any, any>, K extends keyof O>(obj: O, keys: K[]):
 }
 
 function generateImageOptions(providers: ImageModuleProvider[], imageOptions: Omit<CreateImageOptions, 'providers' | 'nuxt' | 'runtimeConfig'>): string {
-  return `
-  ${providers.map(p => `import ${p.importName} from '${p.runtime}'`).join('\n')}
-  
-  export const imageOptions = {
-    ...${JSON.stringify(imageOptions, null, 2)},
-    /** @type {${JSON.stringify(imageOptions.provider)}} */
-    provider: ${JSON.stringify(imageOptions.provider)},
-    providers: {
-      ${providers.map(p => `  ['${p.name}']: { setup: ${p.importName}, defaults: ${JSON.stringify(p.runtimeOptions)} }`).join(',\n')}
-    }
+  const serializedImageOptions = Object.entries(imageOptions)
+    .filter(([key]) => key !== 'provider')
+    .map(([key, value]) => `  ${key}: ${JSON.stringify(value)}`)
+    .join(',\n')
+
+  return `${providers.map(p => `import ${p.importName} from '${p.runtime}'`).join('\n')}
+
+export const imageOptions = {
+${serializedImageOptions},
+  /** @type {${JSON.stringify(imageOptions.provider)}} */
+  provider: ${JSON.stringify(imageOptions.provider)},
+  providers: {
+    ${providers.map(p => `  ['${p.name}']: { setup: ${p.importName}, defaults: ${JSON.stringify(p.runtimeOptions)} }`).join(',\n')}
   }
+}
 `
 }


### PR DESCRIPTION
### 🔗 Linked issue

resolves https://github.com/nuxt/image/issues/2242

### 📚 Description

Removes duplicated `provider` key in generated image options and slightly adjusts formatting.