### PR TITLE
fix(directus): remove deprecated sharpen option

### DIFF
--- a/docs/content/3.providers/directus.md
+++ b/docs/content/3.providers/directus.md
@@ -88,7 +88,7 @@ A pipeline of transforms to tell Directus how to modify the image before sending
 | **rotate**| \[angle?: number, options?: \{ background: Color \} \]| \['rotate', 90\] or \['rotate', 90, \{ background: 'white' \} \]|
 | **flip**| \[]| \['flip'\]|
 | **flop**| \[]| \['flop'\]|
-| **sharpen**| \[sigma?: number\] \| \[options?: \{ sigma?: number, m1?: number, m2?: number, x1?: number, y2?: number, y3?: number \} \]| \['sharpen', 1.5\] or \['sharpen', \{ sigma: 1.5, m1: 0.5 \} \]|
+| **sharpen**| \[options?: \{ sigma?: number, m1?: number, m2?: number, x1?: number, y2?: number, y3?: number \} \]| \['sharpen'\] or \['sharpen', \{ sigma: 1.5, m1: 0.5 \} \]|
 | **median**| \[size?: number\]| \['median', 5\]|
 | **blur**| \[sigma?: number\] \| \[options?: \{ sigma?: number, precision?: 'integer' \| 'float' \| 'approximate', minAmplitude?: number \} \]| \['blur', 2\] or \['blur', \{ sigma: 2, precision: 'float' \} \]|
 | **flatten**| \[options?: \{ background: Color \} \]| \['flatten', \{ background: 'black' \} \]|

--- a/src/runtime/providers/directus.ts
+++ b/src/runtime/providers/directus.ts
@@ -7,7 +7,7 @@ type SharpOperationMap = {
   rotate: [angle?: number, options?: { background: Color }]
   flip: []
   flop: []
-  sharpen: [sigma?: number] | [options?: { sigma?: number, m1?: number, m2?: number, x1?: number, y2?: number, y3?: number }]
+  sharpen: [options?: { sigma?: number, m1?: number, m2?: number, x1?: number, y2?: number, y3?: number }]
   median: [size?: number]
   blur: [sigma?: number] | [options?: { sigma?: number, precision?: 'integer' | 'float' | 'approximate', minAmplitude?: number }]
   flatten: [options?: { background: Color }]


### PR DESCRIPTION
https://github.com/directus/directus/pull/27990 bumps from Sharp 0.34.5 to 0.35.3
-  https://sharp.pixelplumbing.com/changelog/v0.35.0/ deprecated one of the sharpen options.

### 🔗 Linked issue

resolves nuxt/image#2293

### 📚 Description

updated sharp operation to match v0.35 shape.

The currently released version of nuxt/image is fully functional for Directus <12.1.1 ; no rush no merging the fix.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
