### PR TITLE
ci: only run `release` workflows in nuxt org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
   # or update a draft release PR, and close any superseded release PRs
   # (e.g. `release/v1.0.1` when the bump is now `release/v1.1.0`).
   pr:
-    if: github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: github.repository_owner == 'nuxt' && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
     permissions:
       contents: write       # push the `release/vX.Y.Z` branch and delete superseded ones
@@ -32,7 +32,8 @@ jobs:
   # the head-repo guard keeps merged fork PRs from triggering it.
   release:
     if: |
-      github.event_name == 'pull_request'
+      github.repository_owner == 'nuxt' 
+      && github.event_name == 'pull_request'
       && github.event.pull_request.merged == true
       && startsWith(github.event.pull_request.head.ref, 'release/v')
       && github.event.pull_request.head.repo.full_name == github.repository
@@ -54,7 +55,7 @@ jobs:
   # artifact. See "Lifecycle scripts" below for what runs where. Manual
   # recovery uses the same path (Run workflow -> pick a `v*` tag).
   pack:
-    if: github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')
+    if: github.repository_owner == 'nuxt' && github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     concurrency:
       group: pack-${{ github.ref }}
@@ -70,7 +71,8 @@ jobs:
   # artifact and stages it for publish.
   publish:
     if: |
-      github.event_name == 'workflow_dispatch'
+      github.repository_owner == 'nuxt' 
+      && github.event_name == 'workflow_dispatch'
       && startsWith(github.ref, 'refs/tags/v')
       && needs.pack.outputs.files != '[]'
     needs: pack


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->


### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

The 'release' actions are running in forks. This PR ensures they only run in the Nuxt org. 

See https://github.com/hacknug/image/pull/1 for reference.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
