### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/src/runtime/components/NuxtImg.vue
+++ b/src/runtime/components/NuxtImg.vue
@@ -125,7 +125,7 @@ if (import.meta.server && props.preload) {
 
 // Prerender static images
 if (import.meta.server && import.meta.prerender) {
-  prerenderStaticImages(src.value, sizes.value.srcset, useRequestEvent())
+  prerenderStaticImages(src.value, sizes.value.srcset, useRequestEvent(), $img.options.runtimeConfig)
 }
 
 const initialLoad = useNuxtApp().isHydrating

--- a/src/runtime/components/NuxtPicture.vue
+++ b/src/runtime/components/NuxtPicture.vue
@@ -144,7 +144,7 @@ if (import.meta.server && props.preload) {
 // Prerender static images
 if (import.meta.server && import.meta.prerender) {
   for (const src of sources.value) {
-    prerenderStaticImages(src.src, src.srcset, useRequestEvent())
+    prerenderStaticImages(src.src, src.srcset, useRequestEvent(), $img.options.runtimeConfig)
   }
 }
 

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -15,7 +15,7 @@ export function createImage(globalOptions: CreateImageOptions) {
 
     // Prerender static images
     if (import.meta.server && import.meta.prerender && globalOptions.event) {
-      prerenderStaticImages(image.url, undefined, globalOptions.event)
+      prerenderStaticImages(image.url, undefined, globalOptions.event, globalOptions.runtimeConfig)
     }
 
     return image

--- a/src/runtime/utils/prerender.ts
+++ b/src/runtime/utils/prerender.ts
@@ -1,15 +1,18 @@
+import type { RuntimeConfig } from '@nuxt/schema'
 import type { H3Event } from 'h3'
 import { appendHeader } from 'h3'
 
-export function prerenderStaticImages(src = '', srcset = '', event?: H3Event) {
+export function prerenderStaticImages(src = '', srcset = '', event?: H3Event, runtimeConfig?: RuntimeConfig) {
   if (!import.meta.server || !import.meta.prerender || !event) {
     return
   }
 
+  const ipx = runtimeConfig?.ipx as { baseURL?: string } | undefined
+  const baseURL = (ipx?.baseURL || '/_ipx').replace(/\/+$/, '')
   const paths = [
     src,
     ...srcset.split(', ').map(s => s.trim().split(' ')[0]!.trim()),
-  ].filter(s => s && s.includes('/_ipx/'))
+  ].filter(s => s && s.includes(`${baseURL}/`))
 
   if (!paths.length) {
     return

--- a/test/e2e/generate.test.ts
+++ b/test/e2e/generate.test.ts
@@ -12,6 +12,9 @@ await setup({
   nuxtConfig: {
     image: {
       inject: false,
+      ipx: {
+        baseURL: '/static-images',
+      },
     },
     nitro: {
       prerender: {
@@ -31,22 +34,22 @@ describe('ipx provider', () => {
   it('generates static files', async () => {
     const ctx = useTestContext()
     const outputDir = resolve(ctx.nuxt!.options.nitro.output?.dir || '', 'public')
-    const files = await glob('_ipx/**/*', { cwd: outputDir })
+    const files = await glob('static-images/**/*', { cwd: outputDir })
     expect(files.sort()).toMatchInlineSnapshot(`
       [
-        "_ipx/_/images/nuxt.png",
-        "_ipx/s_300x300/images/colors-layer-config.jpg",
-        "_ipx/s_300x300/images/colors-layer.jpg",
-        "_ipx/s_300x300/images/colors.jpg",
-        "_ipx/s_300x300/images/everest.jpg",
-        "_ipx/s_300x300/images/tacos.svg",
-        "_ipx/s_300x300/unsplash/photo-1606112219348-204d7d8b94ee",
-        "_ipx/s_600x600/images/colors-layer-config.jpg",
-        "_ipx/s_600x600/images/colors-layer.jpg",
-        "_ipx/s_600x600/images/colors.jpg",
-        "_ipx/s_600x600/images/everest.jpg",
-        "_ipx/s_600x600/images/tacos.svg",
-        "_ipx/s_600x600/unsplash/photo-1606112219348-204d7d8b94ee",
+        "static-images/_/images/nuxt.png",
+        "static-images/s_300x300/images/colors-layer-config.jpg",
+        "static-images/s_300x300/images/colors-layer.jpg",
+        "static-images/s_300x300/images/colors.jpg",
+        "static-images/s_300x300/images/everest.jpg",
+        "static-images/s_300x300/images/tacos.svg",
+        "static-images/s_300x300/unsplash/photo-1606112219348-204d7d8b94ee",
+        "static-images/s_600x600/images/colors-layer-config.jpg",
+        "static-images/s_600x600/images/colors-layer.jpg",
+        "static-images/s_600x600/images/colors.jpg",
+        "static-images/s_600x600/images/everest.jpg",
+        "static-images/s_600x600/images/tacos.svg",
+        "static-images/s_600x600/unsplash/photo-1606112219348-204d7d8b94ee",
       ]
     `)
   })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #1394

### 📚 Description

The prerender check always looked for `/_ipx/`, so generated images were skipped when IPX used a custom base URL. This passes the configured base URL through `NuxtImg`, `NuxtPicture`, and `getImage` so the check matches the URL that was generated.

Adds an end-to-end case for a custom base URL. The focused generate tests, lint, and build pass locally. The broader provider suite only hit two external Aliyun network timeouts.