### PR TITLE
fix(ipx): use the configured baseURL when prerendering static images

### DIFF
--- a/src/runtime/components/NuxtImg.vue
+++ b/src/runtime/components/NuxtImg.vue
@@ -25,6 +25,7 @@ import { prerenderStaticImages } from '../utils/prerender'
 import { markFeatureUsage } from '../utils/performance'
 import { useImageProps } from '../utils/props'
 import type { BaseImageProps } from '../utils/props'
+import type { IPXRuntimeConfig } from '../providers/ipx'
 import type { ProviderDefaults, ConfiguredImageProviders } from '@nuxt/image'
 
 import { useHead, useNuxtApp, useRequestEvent } from '#imports'
@@ -125,7 +126,8 @@ if (import.meta.server && props.preload) {
 
 // Prerender static images
 if (import.meta.server && import.meta.prerender) {
-  prerenderStaticImages(src.value, sizes.value.srcset, useRequestEvent())
+  const ipxBaseURL = ($img.options.runtimeConfig.ipx as IPXRuntimeConfig | undefined)?.baseURL
+  prerenderStaticImages(src.value, sizes.value.srcset, useRequestEvent(), ipxBaseURL)
 }
 
 const initialLoad = useNuxtApp().isHydrating

--- a/src/runtime/components/NuxtPicture.vue
+++ b/src/runtime/components/NuxtPicture.vue
@@ -32,6 +32,7 @@ import { markFeatureUsage } from '../utils/performance'
 import { useImage } from '../composables'
 import { useImageProps } from '../utils/props'
 import type { BaseImageProps } from '../utils/props'
+import type { IPXRuntimeConfig } from '../providers/ipx'
 import type { DataAttributes } from '../types'
 import type { ConfiguredImageProviders, ProviderDefaults } from '@nuxt/image'
 
@@ -143,8 +144,9 @@ if (import.meta.server && props.preload) {
 
 // Prerender static images
 if (import.meta.server && import.meta.prerender) {
+  const ipxBaseURL = ($img.options.runtimeConfig.ipx as IPXRuntimeConfig | undefined)?.baseURL
   for (const src of sources.value) {
-    prerenderStaticImages(src.src, src.srcset, useRequestEvent())
+    prerenderStaticImages(src.src, src.srcset, useRequestEvent(), ipxBaseURL)
   }
 }
 

--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -3,6 +3,7 @@ import { hasProtocol, parseURL, joinURL, withLeadingSlash } from 'ufo'
 import { imageMeta } from './utils/meta'
 import { checkDensities, parseDensities, parseSize, parseSizes } from './utils'
 import { prerenderStaticImages } from './utils/prerender'
+import type { IPXRuntimeConfig } from './providers/ipx'
 import type { ImageOptions, ImageSizesOptions, CreateImageOptions, ResolvedImage, ImageCTX, $Img, ImageSizes, ImageSizesVariant, ConfiguredImageProviders } from '@nuxt/image'
 
 export function createImage(globalOptions: CreateImageOptions) {
@@ -15,7 +16,7 @@ export function createImage(globalOptions: CreateImageOptions) {
 
     // Prerender static images
     if (import.meta.server && import.meta.prerender && globalOptions.event) {
-      prerenderStaticImages(image.url, undefined, globalOptions.event)
+      prerenderStaticImages(image.url, undefined, globalOptions.event, (globalOptions.runtimeConfig.ipx as IPXRuntimeConfig | undefined)?.baseURL)
     }
 
     return image

--- a/src/runtime/utils/prerender.ts
+++ b/src/runtime/utils/prerender.ts
@@ -1,15 +1,18 @@
 import type { H3Event } from 'h3'
 import { appendHeader } from 'h3'
+import { withoutTrailingSlash } from 'ufo'
 
-export function prerenderStaticImages(src = '', srcset = '', event?: H3Event) {
+export function prerenderStaticImages(src = '', srcset = '', event?: H3Event, ipxBaseURL?: string) {
   if (!import.meta.server || !import.meta.prerender || !event) {
     return
   }
 
+  const baseURL = withoutTrailingSlash(ipxBaseURL || '/_ipx')
+
   const paths = [
     src,
     ...srcset.split(', ').map(s => s.trim().split(' ')[0]!.trim()),
-  ].filter(s => s && s.includes('/_ipx/'))
+  ].filter(s => s && s.includes(`${baseURL}/`))
 
   if (!paths.length) {
     return

--- a/test/e2e/generate-base-url.test.ts
+++ b/test/e2e/generate-base-url.test.ts
@@ -1,0 +1,56 @@
+import { fileURLToPath } from 'node:url'
+
+import { describe, it, expect } from 'vitest'
+import { setup, useTestContext } from '@nuxt/test-utils'
+import { useNuxt } from '@nuxt/kit'
+import { resolve } from 'pathe'
+import { glob } from 'tinyglobby'
+
+await setup({
+  rootDir: fileURLToPath(new URL('../../playground', import.meta.url)),
+  build: true,
+  nuxtConfig: {
+    image: {
+      inject: false,
+      ipx: {
+        baseURL: '/static-images',
+      },
+    },
+    nitro: {
+      prerender: {
+        failOnError: false,
+      },
+    },
+    hooks: {
+      'modules:before'() {
+        const nuxt = useNuxt()
+        nuxt.options.nitro.prerender = { routes: ['/provider/ipx'], failOnError: false }
+      },
+    },
+  },
+})
+
+describe('ipx provider with custom baseURL', () => {
+  it('generates static files', async () => {
+    const ctx = useTestContext()
+    const outputDir = resolve(ctx.nuxt!.options.nitro.output?.dir || '', 'public')
+    const files = await glob('static-images/**/*', { cwd: outputDir })
+    expect(files.sort()).toMatchInlineSnapshot(`
+      [
+        "static-images/_/images/nuxt.png",
+        "static-images/s_300x300/images/colors-layer-config.jpg",
+        "static-images/s_300x300/images/colors-layer.jpg",
+        "static-images/s_300x300/images/colors.jpg",
+        "static-images/s_300x300/images/everest.jpg",
+        "static-images/s_300x300/images/tacos.svg",
+        "static-images/s_300x300/unsplash/photo-1606112219348-204d7d8b94ee",
+        "static-images/s_600x600/images/colors-layer-config.jpg",
+        "static-images/s_600x600/images/colors-layer.jpg",
+        "static-images/s_600x600/images/colors.jpg",
+        "static-images/s_600x600/images/everest.jpg",
+        "static-images/s_600x600/images/tacos.svg",
+        "static-images/s_600x600/unsplash/photo-1606112219348-204d7d8b94ee",
+      ]
+    `)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

resolves #1394

### 📚 Description

Prerendering skips every IPX image when you set a custom `baseURL`, because the filter in `prerenderStaticImages` hardcodes `/_ipx/`. I changed it to use the configured base URL and fall back to `/_ipx`, so nothing changes on the default. I also strip a trailing slash, since `'/static-images/'` would otherwise fail the same silent way.

I pass the base URL in from the three call sites, which all have it already, instead of reading it inside the util: the unit tests import `src/runtime/utils/` too, and `#imports` does not resolve there. Also added a new test file, `test/e2e/generate-base-url.test.ts`, instead of editing the existing generate test, so the default path stays covered. It fails without the change.

The CI tests passed except the two `aliyun` e2e cases that time out for me locally because their host is unreachable from my network.  This is the same as a clean `main`, so unlikely the result of my changes in this PR.