### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/src/runtime/image.ts
+++ b/src/runtime/image.ts
@@ -217,11 +217,11 @@ function getSizesVariant(key: string, size: string, height: number | undefined, 
     return undefined
   }
   let _cWidth = Number.parseInt(size)
-  if (!screenMaxWidth || !_cWidth) {
-    return undefined
-  }
   if (isFluid) {
     _cWidth = Math.round((_cWidth / 100) * screenMaxWidth)
+  }
+  if (!screenMaxWidth || !_cWidth) {
+    return undefined
   }
   const _cHeight = hwRatio ? Math.round(_cWidth * hwRatio) : height
   return {

--- a/test/nuxt/image.test.ts
+++ b/test/nuxt/image.test.ts
@@ -390,6 +390,20 @@ describe('Sizes and densities behavior', () => {
     // Should have sizes attribute
     expect(sizes).toBeTruthy()
   })
+
+  it('unprefixed fluid size below 50vw does not emit a 0w descriptor', () => {
+    const img = mountImage({
+      src: '/image.png',
+      width: 300,
+      height: 400,
+      sizes: '22vw sm:22vw',
+    })
+
+    const srcset = img.find('img').element.getAttribute('srcset')
+
+    // Should drop the degenerate default-bucket variant instead of emitting 0w
+    expect(srcset).not.toMatch(/\s0w\b/)
+  })
 })
 
 describe('Preset sizes and densities inheritance', () => {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #2320

### 📚 Description

`getSizesVariant` checks for a zero-width candidate before applying the fluid vw-to-pixel conversion. An unprefixed size below 50vw passes that check with its raw percentage value, then rounds down to 0 during conversion, so it ends up in the srcset as an invalid `0w` descriptor. Moving the zero check after the conversion drops that candidate instead of emitting it. Prefixed sizes against real screen breakpoints are unaffected since their widths are large enough that the conversion doesn't round to zero.