### PR TITLE
🚨 unwelcome pr from bot 🚨

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -71,12 +71,16 @@ export function isBuiltInProvider(provider: ImageModuleProvider) {
 type ImageProviderName = typeof BuiltInProviders[number]
 
 // https://docs.netlify.com/image-cdn/create-integration/
-const netlifySetup: ProviderSetup = (_providerOptions, moduleOptions, nuxt: Nuxt) => {
+export const netlifySetup: ProviderSetup = (_providerOptions, moduleOptions, nuxt: Nuxt) => {
   if (moduleOptions.domains?.length > 0) {
     nuxt.options.nitro = defu(nuxt.options.nitro, {
       netlify: {
         images: {
-          remote_images: moduleOptions.domains.map(domain => `https?:\\/\\/${domain.replaceAll('.', '\\.')}\\/.*`),
+          // Anchor the generated pattern at both ends (`^`/`$`). Without the
+          // anchors, a consumer that treats these entries as a substring match
+          // could accept a foreign host that merely embeds an allowlisted
+          // domain elsewhere in the URL, defeating the allowlist.
+          remote_images: moduleOptions.domains.map(domain => `^https?:\\/\\/${domain.replaceAll('.', '\\.')}\\/.*$`),
         },
       },
     })

--- a/test/unit/netlify-remote-images.test.ts
+++ b/test/unit/netlify-remote-images.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { netlifySetup } from '../../src/provider'
+import type { ModuleOptions } from '../../src/module'
+
+// netlifySetup writes a list of regex source strings into
+// nitro.netlify.images.remote_images, one per configured domain.
+function generateRemoteImages(domains: string[]): string[] {
+  const nuxt = { options: { nitro: {} } }
+  netlifySetup(
+    {} as unknown as Parameters<typeof netlifySetup>[0],
+    { domains } as unknown as ModuleOptions,
+    nuxt as unknown as Parameters<typeof netlifySetup>[2],
+  )
+  return (nuxt.options.nitro as { netlify?: { images?: { remote_images?: string[] } } })?.netlify?.images?.remote_images ?? []
+}
+
+describe('netlify remote_images patterns', () => {
+  it('generates one pattern per domain', () => {
+    const patterns = generateRemoteImages(['images.example.com', 'cdn.example.org'])
+    expect(patterns).toHaveLength(2)
+  })
+
+  it('anchors every generated pattern at both ends', () => {
+    const patterns = generateRemoteImages(['images.example.com'])
+    for (const pattern of patterns) {
+      expect(pattern.startsWith('^')).toBe(true)
+      expect(pattern.endsWith('$')).toBe(true)
+    }
+  })
+
+  it('matches a legitimate URL on the allowlisted domain', () => {
+    const [pattern] = generateRemoteImages(['images.example.com'])
+    expect(new RegExp(pattern!).test('https://images.example.com/photo.jpg')).toBe(true)
+  })
+
+  it('does not match a foreign host that embeds the allowlisted domain in its path or query', () => {
+    const [pattern] = generateRemoteImages(['images.example.com'])
+    const re = new RegExp(pattern!)
+    // A consumer that runs the pattern with a substring/`RegExp.test` match
+    // against a full URL would otherwise treat these attacker-controlled
+    // hosts as allowlisted, because the allowlisted domain appears somewhere
+    // inside the string.
+    expect(re.test('https://attacker.example/?u=https://images.example.com/x')).toBe(false)
+    expect(re.test('https://images.example.com.attacker.example/x')).toBe(false)
+    expect(re.test('https://attacker.example/https://images.example.com/x')).toBe(false)
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

No separate tracking issue — this is a small, self-contained hardening change to the Netlify provider setup.

### 📚 Description

`netlifySetup` generates one regex per configured `domain` for `nitro.netlify.images.remote_images`. The generated sources were **unanchored**:

```
https?:\/\/${domain}\/.*
```

An unanchored source only requires the allowlisted origin to appear *somewhere* in the candidate string. Any consumer that evaluates these entries as a substring / `RegExp.test` match against a full URL would therefore also accept a foreign host that merely embeds an allowlisted domain elsewhere in the URL, e.g. `https://attacker.example/?u=https://images.example.com/x` or `https://images.example.com.attacker.example/x`. That is an allowlist bypass with SSRF shape for such a consumer.

The change anchors the generated pattern at both ends:

```
^https?:\/\/${domain}\/.*$
```

so a pattern can only match a URL that actually *starts* with an allowlisted origin.

**Scope / honesty note:** I checked Netlify's production Image CDN edge against a real site and it already anchors and rejects these attacker inputs, so this is **not** an exploitable SSRF on the Netlify platform. This PR is defense-in-depth: it makes the emitted `remote_images` sources correct and safe on their own, which matters for self-hosted / other consumers of the same config (e.g. running the images primitive outside Netlify's edge). No behavior change for legitimate allowlisted URLs.

Added a unit test (`test/unit/netlify-remote-images.test.ts`) that asserts every generated pattern is anchored and that foreign hosts embedding an allowlisted domain do not match — it fails on the previous unanchored code and passes with this change. `netlifySetup` is now exported so it can be exercised directly.

